### PR TITLE
Set default parameter for validation stringency

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -90,6 +90,6 @@ annotations:
 params:
   cutadapt: ""
   picard:
-    MarkDuplicates: ""
+    MarkDuplicates: "VALIDATION_STRINGENCY=LENIENT"
   gatk:
     BaseRecalibrator: ""


### PR DESCRIPTION
This PR adresses an issue where duplicate marking fails with an validation error.
This can be resolved by setting the validation stringency to `lenient`.

As this error occurred on every data set we processed @christopher-schroeder and I propose to set this as default parameter for the workflow.