### PR TITLE
Correct handling of single end data

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -91,6 +91,6 @@ annotations:
 params:
   cutadapt: ""
   picard:
-    MarkDuplicates: ""
+    MarkDuplicates: "VALIDATION_STRINGENCY=LENIENT"
   gatk:
     BaseRecalibrator: ""

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -38,7 +38,7 @@ def get_merged(wildcards):
     if is_paired_end(wildcards.sample):
         return ["merged/{sample}.1.fastq.gz",
                 "merged/{sample}.2.fastq.gz"]
-    return "merged/{sample}.fastq.gz"
+    return "merged/{sample}.single.fastq.gz"
 
 def get_group_aliases(wildcards):
     return samples.loc[samples["group"] == wildcards.group]["alias"]

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -40,7 +40,7 @@ rule cutadapt_se:
     input:
         get_raw_fastq
     output:
-        fastq="trimmed/{sample}-{unit}.fastq.gz",
+        fastq="trimmed/{sample}-{unit}.single.fastq.gz",
         qc="trimmed/{sample}-{unit}.qc.txt"
     params:
         others = config["params"]["cutadapt"],
@@ -55,7 +55,7 @@ rule merge_fastqs:
     input:
         lambda w: expand("trimmed/{{sample}}-{unit}.{{read}}.fastq.gz", unit=units.loc[w.sample, "unit_name"])
     output:
-        "merged/{sample}.{read,(1|2)}.fastq.gz"
+        "merged/{sample}.{read,(single|1|2)}.fastq.gz"
     run:
         if input[0].endswith(".gz"):
             shell("cat {input} > {output}")


### PR DESCRIPTION
This PR addresses an issue (found by @jafors and @dlaehnemann) causing the workflow to break when applied to single end data.
This occurs while merging fastq files as a `read`-wildcard is expected. 