### PR TITLE
Stream data to gz-file

### DIFF
--- a/workflow/rules/annotation/pass2.smk
+++ b/workflow/rules/annotation/pass2.smk
@@ -70,7 +70,7 @@ if is_activated("annotations/dbnsfp"):
             """
             (unzip -p {input} "*_variant.chr1.gz" | zcat |
             head -n 1 ; unzip -p {input} "*_variant.chr*" |
-            zcat | grep -v '^#' ) | bgzip -@ {threads} > {output}
+            zcat | grep -v '^#' ) | bgzip -l9 -@ {threads} > {output}
             """
     
     rule annotate_dbnsfp:

--- a/workflow/rules/annotation/pass2.smk
+++ b/workflow/rules/annotation/pass2.smk
@@ -68,11 +68,9 @@ if is_activated("annotations/dbnsfp"):
         threads: 4
         shell:
             """
-            unzip {input} -d resources/dbnsfp/ &&
-            (zcat resources/dbnsfp/*_variant.chr1.gz |
-            head -n 1 ; zcat resources/dbnsfp/*_variant.chr* |
-            grep -v '^#' ) | bgzip -@ {threads} > {output} &&
-            rm -r resources/dbnsfp
+            (unzip -p {input} "*_variant.chr1.gz" | zcat |
+            head -n 1 ; unzip -p {input} "*_variant.chr*" |
+            zcat | grep -v '^#' ) | bgzip -@ {threads} > {output}
             """
     
     rule annotate_dbnsfp:


### PR DESCRIPTION
This PR modifies the rule `dbnsfp_bgzip`:
Previously, data has been written to disk before being compressed to a gzip-file.
This has now been replaced by streaming data directly.