### PR TITLE
Fixed minor bug

### DIFF
--- a/workflow/scripts/build_oncoprint_matrix.py
+++ b/workflow/scripts/build_oncoprint_matrix.py
@@ -22,9 +22,10 @@ for sample_file in input_files:
                 transcripts = rec.info["ANN"]
                 for transcript in transcripts:
                     gene = transcript.split("|")[3]
-                    if gene not in gene_variant_dict:
-                        gene_variant_dict[gene] = set()
-                    gene_variant_dict[gene].add(variant_type)
+                    if gene:
+                        if gene not in gene_variant_dict:
+                            gene_variant_dict[gene] = set()
+                        gene_variant_dict[gene].add(variant_type)
                 break
     for key, value in gene_variant_dict.items():
         gene_variant_dict[key] = ','.join(value)


### PR DESCRIPTION
This PR fixes minor bug while building the oncoprint.
In cases where there is no gene annotated in a transcript the plot holds a row called 'X'.
To circumvent this transcripts without a gene annotation now get skipped. 