### PR TITLE
Optional igv-reports

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -2,6 +2,9 @@ samples: config/samples.tsv
 
 units: config/units.tsv
 
+igv_report:
+  activate: false
+
 ref:
   # Number of chromosomes to consider for calling.
   # The first n entries of the FASTA will be considered.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,6 +2,9 @@ samples: config/samples.tsv
 
 units: config/units.tsv
 
+igv_report:
+  activate: true
+
 ref:
   # Number of chromosomes to consider for calling.
   # The first n entries of the FASTA will be considered.

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -28,9 +28,7 @@ groups = samples["group"].unique()
 
 rule all:
     input:
-        expand("igv-report/{group}.{event}.html",
-               group=groups,
-               event=config["calling"]["fdr-control"]["events"]),
+        get_final_output(),
         get_tmb_targets(),
         expand("plots/oncoprint/{event}.pdf",
                event=config["calling"]["fdr-control"]["events"])

--- a/workflow/envs/annotate_dgidb.yaml
+++ b/workflow/envs/annotate_dgidb.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - rust-bio-tools =0.8
+  - rust-bio-tools =0.9

--- a/workflow/envs/varlociraptor.yaml
+++ b/workflow/envs/varlociraptor.yaml
@@ -2,5 +2,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - varlociraptor =1.5.0
+  - varlociraptor =1.6
   - bcftools =1.9

--- a/workflow/rules/annotation/pass2.smk
+++ b/workflow/rules/annotation/pass2.smk
@@ -44,7 +44,7 @@ rule annotate_dgidb:
     resources:
         dgidb_requests=1
     shell:
-        "rbt vcf-annotate-dgidb {input} |  bcftools view -Ob > {output}"
+        "rbt vcf-annotate-dgidb {input} > {output}"
 
 
 if is_activated("annotations/dbnsfp"):

--- a/workflow/rules/annotation/pass2.smk
+++ b/workflow/rules/annotation/pass2.smk
@@ -44,7 +44,7 @@ rule annotate_dgidb:
     resources:
         dgidb_requests=1
     shell:
-        "rbt vcf-annotate-dgidb {input} > {output}"
+        "rbt vcf-annotate-dgidb {input} |  bcftools view -Ob > {output}"
 
 
 if is_activated("annotations/dbnsfp"):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -12,6 +12,17 @@ validate(config, schema="../schemas/config.schema.yaml")
 
 samples = pd.read_csv(config["samples"], sep="\t", dtype={"sample_name": str, "group": str}).set_index("sample_name", drop=False).sort_index()
 
+def get_final_output():
+    if config["igv_report"]["activate"]:
+        final_output = expand("igv-report/{group}.{event}.html",
+                        group=groups,
+                        event=config["calling"]["fdr-control"]["events"]),
+    else:
+        final_output = expand("merged-calls/{group}.{event}.fdr-controlled.bcf",
+                        group=groups,
+                        event=config["calling"]["fdr-control"]["events"]),
+    return final_output
+
 def _group_or_sample(row):
     group = row.get("group", None)
     if pd.isnull(group):


### PR DESCRIPTION
This PR introduces the possible to create an igv-report as optional output.
As variant calling on WES- or WGS-data return many variants igv-reports may become to big to be opened in a file browser.
In case the report is disabled the workflow creates the fdr controled variants as a bcf-file.