### PR TITLE
Download snpEff database

### DIFF
--- a/workflow/envs/snpeff.yaml
+++ b/workflow/envs/snpeff.yaml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - snpeff =4.3.1t
+

--- a/workflow/rules/annotation/pass1.smk
+++ b/workflow/rules/annotation/pass1.smk
@@ -2,7 +2,7 @@ rule download_snpeff_db:
     output:
         directory("results/refs/snpeff/{ref}")
     params:
-        db_dir=lambda _, output: Path(output).parent.resolve()
+        db_dir=lambda _, output: Path(output[0]).parent.resolve()
     cache: True
     conda:
         "../../envs/snpeff.yaml"

--- a/workflow/rules/annotation/pass1.smk
+++ b/workflow/rules/annotation/pass1.smk
@@ -1,6 +1,18 @@
+rule download_snpeff_db:
+    output:
+        directory("{working_dir}/results/databases/{{ref}}".format(working_dir=os.getcwd()))
+    params:
+        db_dir=os.path.join(os.getcwd(), "results/databases/")
+    cache: True
+    conda:
+        "../../envs/snpeff.yaml"
+    shell:
+        "snpEff download -dataDir {params.db_dir} {wildcards.ref}"
+
 rule snpeff:
     input:
-        "results/calls/{group}.bcf"
+        calls="results/calls/{group}.bcf",
+        db="{working_dir}/results/databases/{build}.{release}".format(working_dir=os.getcwd(), build=config["ref"]["build"], release=config["ref"]["snpeff_release"])
     output:
         calls="results/calls/{group}.annotated.bcf",
         stats="results/snpeff/{group}.html",
@@ -9,6 +21,7 @@ rule snpeff:
         "logs/snpeff/{group}.log"
     params:
         reference="{}.{}".format(config["ref"]["build"], config["ref"]["snpeff_release"]),
-        extra="-Xmx4g"
+        data_dir = os.path.join(os.getcwd(), "results/databases/"),
+        extra="-Xmx4g -nodownload"
     wrapper:
         "0.50.4/bio/snpeff"

--- a/workflow/rules/annotation/pass1.smk
+++ b/workflow/rules/annotation/pass1.smk
@@ -12,7 +12,7 @@ rule download_snpeff_db:
 rule snpeff:
     input:
         calls="results/calls/{group}.bcf",
-        db="results/refs/snpeff/{build}.{release}".format(build=config["ref"]["build"], release=config["ref"]["snpeff_release"])
+        db="results/refs/snpeff/{build}.{snpeff_release}".format(**config["ref"])
     output:
         calls="results/calls/{group}.annotated.bcf",
         stats="results/snpeff/{group}.html",
@@ -20,8 +20,8 @@ rule snpeff:
     log:
         "logs/snpeff/{group}.log"
     params:
-        reference="{}.{}".format(config["ref"]["build"], config["ref"]["snpeff_release"]),
-        data_dir = lambda _, input: Path(input.db).parent.resolve(),
+        reference="{build}.{snpeff_release}".format(**config["ref"]),
+        data_dir=lambda _, input: Path(input.db).parent.resolve(),
         extra="-Xmx4g -nodownload"
     wrapper:
         "0.50.4/bio/snpeff"

--- a/workflow/rules/annotation/pass1.smk
+++ b/workflow/rules/annotation/pass1.smk
@@ -1,8 +1,8 @@
 rule download_snpeff_db:
     output:
-        directory("{working_dir}/results/databases/{{ref}}".format(working_dir=os.getcwd()))
+        directory("results/refs/snpeff/{ref}")
     params:
-        db_dir=os.path.join(os.getcwd(), "results/databases/")
+        db_dir=lambda _, output: Path(output).parent.resolve()
     cache: True
     conda:
         "../../envs/snpeff.yaml"
@@ -12,7 +12,7 @@ rule download_snpeff_db:
 rule snpeff:
     input:
         calls="results/calls/{group}.bcf",
-        db="{working_dir}/results/databases/{build}.{release}".format(working_dir=os.getcwd(), build=config["ref"]["build"], release=config["ref"]["snpeff_release"])
+        db="results/refs/snpeff/{build}.{release}".format(build=config["ref"]["build"], release=config["ref"]["snpeff_release"])
     output:
         calls="results/calls/{group}.annotated.bcf",
         stats="results/snpeff/{group}.html",
@@ -21,7 +21,7 @@ rule snpeff:
         "logs/snpeff/{group}.log"
     params:
         reference="{}.{}".format(config["ref"]["build"], config["ref"]["snpeff_release"]),
-        data_dir = os.path.join(os.getcwd(), "results/databases/"),
+        data_dir = lambda _, input: Path(input.db).parent.resolve(),
         extra="-Xmx4g -nodownload"
     wrapper:
         "0.50.4/bio/snpeff"

--- a/workflow/rules/annotation/pass1.smk
+++ b/workflow/rules/annotation/pass1.smk
@@ -23,5 +23,7 @@ rule snpeff:
         reference="{build}.{snpeff_release}".format(**config["ref"]),
         data_dir=lambda _, input: Path(input.db).parent.resolve(),
         extra="-Xmx4g -nodownload"
+    resources:
+        mem_mb=4000
     wrapper:
         "0.50.4/bio/snpeff"


### PR DESCRIPTION
This PR adds a rule for downloading the snpEff database before annotating.
Previously the download was initiated by each snpEff annotation call.
This could lead to race conditions where each call downloads the database to the same temporary directory which got deleted after the first download finished.