### PR TITLE
Fix for ambiguous rules

### DIFF
--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -119,16 +119,3 @@ if is_activated("annotations/dbnsfp"):
         shell:
             "(bcftools view --threads {threads} {input.bcf} | SnpSift dbnsfp -db {input.db} -f {params.fields} {params.extra} /dev/stdin | "
             "sed 's/\\(^##INFO=<ID=dbNSFP_\\w*,Number=\\)A/\\1./g' | bcftools view -Ob --threads {threads} > {output}) 2> {log}"
-
-
-    rule create_dbnsfp_tabix_index:
-        input:
-            "resources/{file}.txt.gz",
-        output:
-            "resources/{file}.txt.gz.tbi"
-        log:
-            "logs/tabix/{file}.log"
-        conda:
-            "../envs/htslib.yaml"
-        shell:
-            "tabix -s 1 -b 2 -e 2 {input} 2> {log}"

--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -4,7 +4,7 @@ rule download_snpeff_db:
     log:
         "logs/download-snpeff-db/{ref}.log"
     params:
-        db_dir=lambda _, output: Path(output[0]).parent.resolve()
+        db_dir=lambda _, output: str(Path(output[0]).parent.resolve())
     conda:
         "../envs/snpeff.yaml"
     cache: True

--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -123,9 +123,9 @@ if is_activated("annotations/dbnsfp"):
 
     rule create_dbnsfp_tabix_index:
         input:
-            "resources/{file}.gz",
+            "resources/{file}.txt.gz",
         output:
-            "resources/{file}.gz.tbi"
+            "resources/{file}.txt.gz.tbi"
         log:
             "logs/tabix/{file}.log"
         conda:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -170,3 +170,11 @@ def get_annotation_pipes(wildcards, input):
 def get_annotation_vcfs(idx=False):
     fmt = lambda f: f if not idx else f + ".tbi"
     return [fmt(f) for _, f in annotations]
+
+
+def get_tabix_params(wildcards):
+    if wc.format == "vcf":
+        return "-p vcf"
+    if wc.format == "txt":
+        return "-s 1 -b 2 -e 2"
+    return ""

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -173,8 +173,8 @@ def get_annotation_vcfs(idx=False):
 
 
 def get_tabix_params(wildcards):
-    if wc.format == "vcf":
+    if wildcards.format == "vcf":
         return "-p vcf"
-    if wc.format == "txt":
+    if wildcards.format == "txt":
         return "-s 1 -b 2 -e 2"
     return ""

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -173,8 +173,10 @@ def get_annotation_vcfs(idx=False):
 
 
 def get_tabix_params(wildcards):
-    if wildcards.format == "vcf":
-        return "-p vcf"
-    if wildcards.format == "txt":
-        return "-s 1 -b 2 -e 2"
-    return ""
+    try:
+        if wildcards.format == "vcf":
+            return "-p vcf"
+        if wildcards.format == "txt":
+            return "-s 1 -b 2 -e 2"
+    except ValueError:
+        print("Invalid format: {}".format(wildcards.format))

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -173,10 +173,8 @@ def get_annotation_vcfs(idx=False):
 
 
 def get_tabix_params(wildcards):
-    try:
-        if wildcards.format == "vcf":
-            return "-p vcf"
-        if wildcards.format == "txt":
-            return "-s 1 -b 2 -e 2"
-    except ValueError:
-        print("Invalid format: {}".format(wildcards.format))
+    if wildcards.format == "vcf":
+        return "-p vcf"
+    if wildcards.format == "txt":
+        return "-s 1 -b 2 -e 2"
+    raise ValueError("Invalid format for tabix: {}".format(wildcards.format))

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -67,21 +67,6 @@ rule remove_iupac_codes:
     shell:
         "rbt vcf-fix-iupac-alleles < {input} | bcftools view -Oz > {output}"
 
-
-rule tabix_known_variants:
-    input:
-        "resources/{prefix}.vcf.gz"
-    output:
-        "resources/{prefix}.vcf.gz.tbi"
-    log:
-        "logs/tabix/{prefix}.log"
-    params:
-        "-p vcf"
-    cache: True
-    wrapper:
-        "0.45.1/bio/tabix"
-
-
 rule bwa_index:
     input:
         "resources/genome.fasta"

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -20,3 +20,17 @@ rule bam_index:
         "logs/bam-index/{prefix}.log"
     wrapper:
         "0.39.0/bio/samtools/index"
+
+
+rule tabix_known_variants:
+    input:
+        "resources/{prefix}.{format}.gz"
+    output:
+        "resources/{prefix}.{format}.gz.tbi"
+    log:
+        "logs/tabix/{prefix}.{format}.log"
+    params:
+        get_tabix_params
+    cache: True
+    wrapper:
+        "0.45.1/bio/tabix"


### PR DESCRIPTION
This PR fixes an issue preventing snakemake to build the dag, as the output of rules `create_dbnsfp_tabix_index` and `tabix_known_variants` was undistinguishable.