### PR TITLE
Gridss

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -36,6 +36,8 @@ calling:
     activate: true
   freebayes:
     activate: true
+  gridss:
+    activate: true
   # See https://varlociraptor.github.io/docs/calling/#generic-variant-calling
   scenario: config/scenario.yaml
   # See http://snpeff.sourceforge.net/SnpSift.html#filter

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This workflow detects genomic variants with [Delly](https://github.com/dellytool
 
 * Felix Mölder (@FelixMoelder)
 * Johannes Köster (@johanneskoester)
+* Christopher Schröder (@christopher-schroeder)
 
 ## Usage
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -22,6 +22,7 @@ include: "rules/tmb.smk"
 include: "rules/vega.smk"
 include: "rules/utils.smk"
 include: "rules/oncoprint.smk"
+include: "rules/gridss.smk"
 
 groups = samples["group"].unique()
 
@@ -32,6 +33,7 @@ if is_activated("oncoprint/stratify"):
 
 rule all:
     input:
+        expand("results/gridss_vcf/{group}.vcf", group=groups),
         get_final_output(),
         get_tmb_targets(),
         expand("results/plots/oncoprint/{batch}.{event}.pdf",

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -34,8 +34,8 @@ if is_activated("oncoprint/stratify"):
 rule all:
     input:
         expand("results/gridss_vcf/{group}.vcf", group=groups),
-        get_final_output(),
-        get_tmb_targets(),
-        expand("results/plots/oncoprint/{batch}.{event}.pdf",
-               event=config["calling"]["fdr-control"]["events"],
-               batch=batches)
+        #get_final_output(),
+        #get_tmb_targets(),
+        # expand("results/plots/oncoprint/{batch}.{event}.pdf",
+        #        event=config["calling"]["fdr-control"]["events"],
+        #        batch=batches)

--- a/workflow/envs/gridss.yaml
+++ b/workflow/envs/gridss.yaml
@@ -1,0 +1,12 @@
+channels:
+  - conda-forge
+  - bioconda
+  - r
+dependencies:
+  - samtools=1.1.0
+  - ldc=1.13
+  - sambamba=0.7.1
+  - openjdk=11.0.1
+  - r=3.6.0
+  - bwa=0.7.17
+  - gridss=2.8

--- a/workflow/rules/gridss.smk
+++ b/workflow/rules/gridss.smk
@@ -21,13 +21,13 @@ rule GridssCollectMetrics:
         #bam="{sample.bam}"
         bam="results/recal/{sample}.sorted.bam"
     output:
-        insert_size_metrics="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.insert_size_metrics",
-        histogram="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.insert_size_histogram.pdf"
+        insert_size_metrics=temp("tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.insert_size_metrics"),
+        histogram=temp("tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.insert_size_histogram.pdf")
     log:
         "log/gridss/collect_metrics/{sample}.log"
     params:
-        tmp_dir="tmp/{sample}.sorted.bam.gridss.working",
-        prefix="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam",
+        tmp_dir=temp("tmp/{sample}.sorted.bam.gridss.working"),
+        prefix=temp("tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam"),
         maxcoverage=50000,
         metricsrecords=10000000,
         picardoptions=""
@@ -58,14 +58,15 @@ rule GridssCollectMetricsAndExtractSVReads:
         bam="results/recal/{sample}.sorted.bam",
         insert_size_metrics="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.insert_size_metrics",
     output:
-        sv_metrics="tmp/{sample}.sorted.bam.gridss.working/{sample}.bam.sv_metrics",
-        namedsorted_bam="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.namedsorted.bam",
+        sv_metrics=temp("tmp/{sample}.sorted.bam.gridss.working/{sample}.bam.sv_metrics"),
+        namedsorted_bam=temp("tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.namedsorted.bam"),
+        metrics=temp(multiext("tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.bam", ".cigar_metrics", ".coverage.blacklist.bed", ".idsv_metrics", ".insert_size_histogram.pdf", ".insert_size_metrics", ".mapq_metrics", ".tag_metrics")),
     log:
         "log/gridss/collect_metrics_and_extract_sv_reads/{sample}.log"
     params:
-        dir="tmp/{sample}.sorted.bam.gridss.working",
-        prefix="tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.bam",
-        tmp_sort="tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.namedsort",
+        dir=temp("tmp/{sample}.sorted.bam.gridss.working"),
+        prefix=temp("tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.bam"),
+        tmp_sort=temp("tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.namedsort"),
         maxcoverage=50000,
         picardoptions="",
     conda:
@@ -116,15 +117,15 @@ rule GridssComputeSamTags:
         idx=rules.bwa_index.output,
         namedsorted_bam="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.namedsorted.bam",
     output:
-        coordinate_bam="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.coordinate.bam"
+        coordinate_bam=temp("tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.coordinate.bam")
     log:
         "log/gridss/compute_sam_tags/{sample}.log"
     wildcard_constraints:
         sample=sample_constraint
     params:
         working_dir="tmp",
-        tmp_sort="tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.coordinate-tmp",
-        dir="tmp/{sample}.sorted.bam.gridss.working",
+        tmp_sort=temp("tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.coordinate-tmp"),
+        dir=temp("tmp/{sample}.sorted.bam.gridss.working"),
         picardoptions="",
     conda:
         "../envs/gridss.yaml"
@@ -170,8 +171,8 @@ rule GridssSoftClipsToSplitReads:
         idx=rules.bwa_index.output,
         coordinate_bam="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.coordinate.bam"
     output:
-        primary_sv="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.sc2sr.primary.sv.bam",
-        supp_sv="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.sc2sr.supp.sv.bam",
+        primary_sv=temp("tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.sc2sr.primary.sv.bam"),
+        supp_sv=temp("tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.sc2sr.supp.sv.bam"),
     log:
         "log/gridss/soft_clips_to_split_reads/{sample}.log"
     wildcard_constraints:
@@ -204,7 +205,7 @@ rule GridssSortSv:
     input:
         supp_sv="{x}.sc2sr.supp.sv.bam"
     output:
-        supp_sv="{x}.sc2sr.suppsorted.sv.bam"
+        supp_sv=temp("{x}.sc2sr.suppsorted.sv.bam")
     params:
         tmp_sort="{x}.suppsorted.sv-tmp",
     conda:
@@ -222,7 +223,7 @@ rule GridssMergeSupported:
         primary_sv="{p}/tmp.{x}.bam.sc2sr.primary.sv.bam",
         supp_sv="{p}/tmp.{x}.bam.sc2sr.suppsorted.sv.bam",
     output:
-        merged="{p}/{x}.bam.sv.bam"
+        merged=temp("{p}/{x}.bam.sv.bam")
     conda:
         "../envs/gridss.yaml"
     # wildcard_constraints:
@@ -274,9 +275,9 @@ rule GridssCollectMetricsGroup:
     input:
         assembly="tmp/group.{group}.bam.gridss.working/group.{group}.bam"
     output:
-        idsv_metrics="tmp/group.{group}.bam.gridss.working/group.{group}.bam.idsv_metrics",
-        mapq_metrics="tmp/group.{group}.bam.gridss.working/group.{group}.bam.mapq_metrics",
-        tag_metrics="tmp/group.{group}.bam.gridss.working/group.{group}.bam.tag_metrics",
+        idsv_metrics=temp("tmp/group.{group}.bam.gridss.working/group.{group}.bam.idsv_metrics"),
+        mapq_metrics=temp("tmp/group.{group}.bam.gridss.working/group.{group}.bam.mapq_metrics"),
+        tag_metrics=temp("tmp/group.{group}.bam.gridss.working/group.{group}.bam.tag_metrics"),
     log:
         "log/gridss/collect_metrics_group/{group}.log"
     wildcard_constraints:
@@ -317,8 +318,8 @@ rule GridssSoftClipsToSplitReadsAssembly:
         mapq_metrics="tmp/group.{group}.bam.gridss.working/group.{group}.bam.mapq_metrics",
         tag_metrics="tmp/group.{group}.bam.gridss.working/group.{group}.bam.tag_metrics",
     output:
-        assembly_primary_sv="tmp/group.{group}.bam.gridss.working/tmp.group.{group}.bam.sc2sr.primary.sv.bam",
-        assembly_supp_sv="tmp/group.{group}.bam.gridss.working/tmp.group.{group}.bam.sc2sr.supp.sv.bam",
+        assembly_primary_sv=temp("tmp/group.{group}.bam.gridss.working/tmp.group.{group}.bam.sc2sr.primary.sv.bam"),
+        assembly_supp_sv=temp("tmp/group.{group}.bam.gridss.working/tmp.group.{group}.bam.sc2sr.supp.sv.bam"),
     log:
         "log/gridss/soft_clips_to_split_reads_assembly/{group}.log"
     wildcard_constraints:
@@ -356,9 +357,10 @@ rule GridssIdentifyVariants:
         assembly_sv_index="tmp/group.{group}.bam.gridss.working/group.{group}.bam.sv.bam.bai",
         assembly="tmp/group.{group}.bam.gridss.working/group.{group}.bam",
         ref="results/refs/genome.fasta",
+        svs=lambda wildcards: " ".join(expand("tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.bam.sv.bam", sample=get_group_samples(wildcards))),
         idx=rules.bwa_index.output,
     output:
-        unallocated="tmp/group.{group}.vcf.gridss.working/group.{group}.unallocated.vcf"
+        unallocated=temp("tmp/group.{group}.vcf.gridss.working/group.{group}.unallocated.vcf")
     log:
         "log/gridss/indentify_variants/{group}.log"
     wildcard_constraints:
@@ -393,9 +395,10 @@ rule GridssAnnotateVariants:
         unallocated="tmp/group.{group}.vcf.gridss.working/group.{group}.unallocated.vcf",
         ref="results/refs/genome.fasta",
         idx=rules.bwa_index.output,
+        svs=lambda wildcards: " ".join(expand("tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.bam.sv.bam", sample=get_group_samples(wildcards))),
         assembly="tmp/group.{group}.bam.gridss.working/group.{group}.bam",
     output:
-        allocated="tmp/group.{group}.vcf.gridss.working/group.{group}.allocated.vcf",
+        allocated=temp("tmp/group.{group}.vcf.gridss.working/group.{group}.allocated.vcf"),
     log:
         "log/gridss/annotate_variants/{group}.log"
     wildcard_constraints:

--- a/workflow/rules/gridss.smk
+++ b/workflow/rules/gridss.smk
@@ -36,7 +36,7 @@ rule GridssCollectMetrics:
     wildcard_constraints:
         sample=sample_constraint
     shell: """
-gridss gridss.analysis.CollectGridssMetrics \
+(gridss gridss.analysis.CollectGridssMetrics \
 {jvm_args} \
 TMP_DIR={params.tmp_dir} \
 ASSUME_SORTED=true \
@@ -48,7 +48,7 @@ GRIDSS_PROGRAM=null \
 PROGRAM=null \
 PROGRAM=CollectInsertSizeMetrics \
 STOP_AFTER={params.metricsrecords} \
-{params.picardoptions} 2> {log}
+{params.picardoptions}) > {log} 2>&1
         """
 
 #tmp/EPF-BUR-012-013.bam.gridss.working/tmp.EPF-BUR-012-013.bam.insert_size_metrics
@@ -75,7 +75,7 @@ rule GridssCollectMetricsAndExtractSVReads:
     threads:
         50
     shell: """
-gridss gridss.CollectGridssMetricsAndExtractSVReads \
+(gridss gridss.CollectGridssMetricsAndExtractSVReads \
 {jvm_args} \
 TMP_DIR={params.dir} \
 ASSUME_SORTED=true \
@@ -106,7 +106,7 @@ INCLUDE_DUPLICATES=true \
 -Obam \
 -o {output.namedsorted_bam} \
 -@ {threads} \
-/dev/stdin 2> {log}
+/dev/stdin) > {log} 2>&1
         """
 
 
@@ -131,7 +131,7 @@ rule GridssComputeSamTags:
     threads:
         3
     shell: """
-gridss gridss.ComputeSamTags \
+(gridss gridss.ComputeSamTags \
 {jvm_args} \
 TMP_DIR={params.dir} \
 WORKING_DIR="{params.working_dir}" \
@@ -160,7 +160,7 @@ ASSUME_SORTED=true \
 -Obam \
 -o {output.coordinate_bam} \
 -@ {threads} \
-/dev/stdin 2> {log}
+/dev/stdin) > {log} 2>&1
         """
 
 
@@ -184,7 +184,7 @@ rule GridssSoftClipsToSplitReads:
     threads:
         100
     shell: """
-gridss gridss.SoftClipsToSplitReads \
+(gridss gridss.SoftClipsToSplitReads \
 {jvm_args} \
 -Xmx20G \
 -Dsamjdk.create_index=false \
@@ -196,7 +196,7 @@ I={input.coordinate_bam} \
 O={output.primary_sv} \
 OUTPUT_UNORDERED_RECORDS={output.supp_sv} \
 WORKER_THREADS={threads} \
-{params.picardoptions} 2> {log}
+{params.picardoptions}) > {log} 2>&1
         """
 
 
@@ -254,7 +254,7 @@ rule GridssAssembleBreakends:
     threads:
         100
     shell: """
-gridss gridss.AssembleBreakends \
+(gridss gridss.AssembleBreakends \
 -Dgridss.gridss.output_to_temp_file=true \
 {jvm_args} \
 -Xmx100g \
@@ -266,7 +266,7 @@ REFERENCE_SEQUENCE={input.ref} \
 WORKER_THREADS={threads} \
 O={output.assembly} \
 {params.input_args} \
-{params.picardoptions} 2> {log}
+{params.picardoptions}) > {log} 2>&1
         """
 
 
@@ -289,7 +289,7 @@ rule GridssCollectMetricsGroup:
     conda:
         "../envs/gridss.yaml"
     shell: """
-gridss gridss.analysis.CollectGridssMetrics \
+(gridss gridss.analysis.CollectGridssMetrics \
 {jvm_args} \
 I={input.assembly} \
 O={params.prefix} \
@@ -304,7 +304,7 @@ GRIDSS_PROGRAM=CollectIdsvMetrics \
 GRIDSS_PROGRAM=ReportThresholdCoverage \
 PROGRAM=null \
 PROGRAM=CollectAlignmentSummaryMetrics \
-{params.picardoptions} 2> {log}
+{params.picardoptions}) > {log} 2>&1
         """
 
 
@@ -331,7 +331,7 @@ rule GridssSoftClipsToSplitReadsAssembly:
     threads:
         100
     shell: """
-gridss gridss.SoftClipsToSplitReads \
+(gridss gridss.SoftClipsToSplitReads \
 {jvm_args} \
 -Xmx50G \
 -Dgridss.async.buffersize=16 \
@@ -345,7 +345,7 @@ I={input.assembly} \
 O={output.assembly_primary_sv} \
 OUTPUT_UNORDERED_RECORDS={output.assembly_supp_sv} \
 REALIGN_ENTIRE_READ=true \
-{params.picardoptions} >2 {log}
+{params.picardoptions}) > {log} 2>&1
         """
 
 
@@ -372,7 +372,7 @@ rule GridssIdentifyVariants:
     threads:
         100
     shell: """
-gridss gridss.IdentifyVariants \
+(gridss gridss.IdentifyVariants \
 -Dgridss.output_to_temp_file=true \
 {jvm_args} \
 -Xmx50g \
@@ -382,7 +382,7 @@ REFERENCE_SEQUENCE={input.ref} \
 WORKER_THREADS={threads} \
 {params.input_args} \
 ASSEMBLY={input.assembly} \
-OUTPUT_VCF={output.unallocated} 2> {log}
+OUTPUT_VCF={output.unallocated}) > {log} 2>&1
         """
 
 rule GridssAnnotateVariants:
@@ -409,7 +409,7 @@ rule GridssAnnotateVariants:
     threads:
         7
     shell:        """
-gridss gridss.AnnotateVariants \
+(gridss gridss.AnnotateVariants \
 -Dgridss.output_to_temp_file=true \
 {jvm_args} \
 -Xmx50g \
@@ -421,7 +421,7 @@ WORKER_THREADS={threads} \
 ASSEMBLY={input.assembly} \
 INPUT_VCF={input.unallocated} \
 OUTPUT_VCF={output.allocated} \
-{params.picardoptions} 2> {log}
+{params.picardoptions}) > {log} 2>&1
         """
 
 rule GridssAnnotateUntemplatedSequence:
@@ -441,7 +441,7 @@ rule GridssAnnotateUntemplatedSequence:
     threads:
         100
     shell: """
-gridss gridss.AnnotateUntemplatedSequence \
+(gridss gridss.AnnotateUntemplatedSequence \
 -Dgridss.output_to_temp_file=true \
 -Xmx4g \
 {jvm_args} \
@@ -451,5 +451,5 @@ REFERENCE_SEQUENCE={input.ref} \
 WORKER_THREADS={threads} \
 INPUT={input.allocated} \
 OUTPUT={output.vcf} \
-{params.picardoptions} 2> {log}
+{params.picardoptions}) > {log} 2>&1
         """

--- a/workflow/rules/gridss.smk
+++ b/workflow/rules/gridss.smk
@@ -1,0 +1,446 @@
+#configfile: "config/config.yaml"
+#include: "rules/common.smk"
+
+#reference = "../strling/ref_bwa/GCA_000001405.15_GRCh38_no_alt_plus_hs38d1_analysis_set.fna"
+
+jvm_args = f"-Dreference_fasta=results/refs/genome.fasta -Dsamjdk.use_async_io_read_samtools=true -Dsamjdk.use_async_io_write_samtools=true -Dsamjdk.use_async_io_write_tribble=true -Dsamjdk.buffer_size=4194304"
+
+group_names = samples["group"].unique()
+sample_names = samples.sample_name.values
+
+sample_constraint = "|".join(sample_names)
+group_constraint = "|".join(group_names)
+
+# rule all:
+#     input:
+#         expand("results/gridss_vcf/group.{group}.vcf", group=group_names)
+
+
+rule GridssCollectMetrics:
+    input:
+        #bam="{sample.bam}"
+        bam="results/recal/{sample}.sorted.bam"
+    output:
+        insert_size_metrics="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.insert_size_metrics",
+        histogram="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.insert_size_histogram.pdf"
+    params:
+        tmp_dir="tmp/{sample}.sorted.bam.gridss.working",
+        prefix="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam",
+        maxcoverage=50000,
+        metricsrecords=10000000,
+        picardoptions=""
+    log:
+        "log/collect_gridss_metrics.{sample}.log"
+    conda:
+        "../envs/gridss.yaml"
+    wildcard_constraints:
+        sample=sample_constraint
+    shell:
+        """
+gridss gridss.analysis.CollectGridssMetrics \
+{jvm_args} \
+TMP_DIR={params.tmp_dir} \
+ASSUME_SORTED=true \
+I={input.bam} \
+O={params.prefix} \
+THRESHOLD_COVERAGE={params.maxcoverage} \
+FILE_EXTENSION=null \
+GRIDSS_PROGRAM=null \
+PROGRAM=null \
+PROGRAM=CollectInsertSizeMetrics \
+STOP_AFTER={params.metricsrecords} \
+{params.picardoptions} 2> {log}
+        """
+
+#tmp/EPF-BUR-012-013.bam.gridss.working/tmp.EPF-BUR-012-013.bam.insert_size_metrics
+
+rule GridssCollectMetricsAndExtractSVReads:
+    threads:
+        50
+    input:
+        bam="results/recal/{sample}.sorted.bam",
+        insert_size_metrics="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.insert_size_metrics",
+    output:
+        sv_metrics="tmp/{sample}.sorted.bam.gridss.working/{sample}.bam.sv_metrics",
+        namedsorted_bam="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.namedsorted.bam",
+    params:
+        dir="tmp/{sample}.sorted.bam.gridss.working",
+        prefix="tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.bam",
+        tmp_sort="tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.namedsort",
+        maxcoverage=50000,
+        picardoptions="",
+    conda:
+        "../envs/gridss.yaml"
+    wildcard_constraints:
+        sample=sample_constraint
+    shell:
+        """
+gridss gridss.CollectGridssMetricsAndExtractSVReads \
+{jvm_args} \
+TMP_DIR={params.dir} \
+ASSUME_SORTED=true \
+I={input.bam} \
+O={params.prefix} \
+THRESHOLD_COVERAGE={params.maxcoverage} \
+FILE_EXTENSION=null \
+GRIDSS_PROGRAM=null \
+GRIDSS_PROGRAM=CollectCigarMetrics \
+GRIDSS_PROGRAM=CollectMapqMetrics \
+GRIDSS_PROGRAM=CollectTagMetrics \
+GRIDSS_PROGRAM=CollectIdsvMetrics \
+GRIDSS_PROGRAM=ReportThresholdCoverage \
+PROGRAM=null \
+PROGRAM=CollectInsertSizeMetrics \
+SV_OUTPUT=/dev/stdout \
+COMPRESSION_LEVEL=0 \
+METRICS_OUTPUT={output.sv_metrics} \
+INSERT_SIZE_METRICS={input.insert_size_metrics} \
+UNMAPPED_READS=false \
+MIN_CLIP_LENGTH=5 \
+INCLUDE_DUPLICATES=true \
+{params.picardoptions} \
+| samtools sort \
+-n \
+-m 100G \
+-T {params.tmp_sort} \
+-Obam \
+-o {output.namedsorted_bam} \
+-@ {threads} \
+/dev/stdin
+        """
+
+
+rule GridssComputeSamTags:
+    threads:
+        3
+    input:
+        ref="results/refs/genome.fasta",
+        idx=rules.bwa_index.output,
+        namedsorted_bam="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.namedsorted.bam",
+    output:
+        coordinate_bam="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.coordinate.bam"
+    params:
+        working_dir="tmp",
+        tmp_sort="tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.coordinate-tmp",
+        dir="tmp/{sample}.sorted.bam.gridss.working",
+        picardoptions="",
+    conda:
+        "../envs/gridss.yaml"
+    wildcard_constraints:
+        sample=sample_constraint
+    shell:
+        """
+gridss gridss.ComputeSamTags \
+{jvm_args} \
+TMP_DIR={params.dir} \
+WORKING_DIR="{params.working_dir}" \
+REFERENCE_SEQUENCE={input.ref} \
+COMPRESSION_LEVEL=0 \
+I={input.namedsorted_bam} \
+O=/dev/stdout \
+RECALCULATE_SA_SUPPLEMENTARY=true \
+SOFTEN_HARD_CLIPS=true \
+FIX_MATE_INFORMATION=true \
+FIX_DUPLICATE_FLAG=true \
+FIX_SA=true \
+FIX_MISSING_HARD_CLIP=true \
+TAGS=null \
+TAGS=NM \
+TAGS=SA \
+TAGS=R2 \
+TAGS=Q2 \
+TAGS=MC \
+TAGS=MQ \
+ASSUME_SORTED=true \
+{params.picardoptions} \
+| samtools sort \
+-m 100G \
+-T {params.tmp_sort} \
+-Obam \
+-o {output.coordinate_bam} \
+-@ {threads} \
+/dev/stdin
+        """
+
+
+rule GridssSoftClipsToSplitReads:
+    threads:
+        100
+    input:
+        ref="results/refs/genome.fasta",
+        idx=rules.bwa_index.output,
+        coordinate_bam="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.coordinate.bam"
+    output:
+        primary_sv="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.sc2sr.primary.sv.bam",
+        supp_sv="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.sc2sr.supp.sv.bam",
+    params:
+        working_dir="tmp",
+        picardoptions="",
+    conda:
+        "../envs/gridss.yaml"
+    wildcard_constraints:
+        sample=sample_constraint
+    shell:
+        """
+gridss gridss.SoftClipsToSplitReads \
+{jvm_args} \
+-Xmx20G \
+-Dsamjdk.create_index=false \
+-Dgridss.gridss.output_to_temp_file=true \
+TMP_DIR={params.working_dir} \
+WORKING_DIR={params.working_dir} \
+REFERENCE_SEQUENCE={input.ref} \
+I={input.coordinate_bam} \
+O={output.primary_sv} \
+OUTPUT_UNORDERED_RECORDS={output.supp_sv} \
+WORKER_THREADS={threads} \
+{params.picardoptions}
+        """
+
+
+rule GridssSortSv:
+    threads:
+        64
+    input:
+        supp_sv="{x}.sc2sr.supp.sv.bam"
+    output:
+        supp_sv="{x}.sc2sr.suppsorted.sv.bam"
+    params:
+        tmp_sort="{x}.suppsorted.sv-tmp",
+    conda:
+        "../envs/gridss.yaml"
+    shell:
+        "samtools sort -m 100G -@ {threads} -T {params.tmp_sort} -Obam -o {output.supp_sv} {input.supp_sv}"
+
+
+rule GridssMergeSupported:
+    threads:
+        64
+    input:
+        primary_sv="{p}/tmp.{x}.bam.sc2sr.primary.sv.bam",
+        supp_sv="{p}/tmp.{x}.bam.sc2sr.suppsorted.sv.bam",
+    output:
+        merged="{p}/{x}.bam.sv.bam"
+    conda:
+        "../envs/gridss.yaml"
+    # wildcard_constraints:
+    #     x=sample_constraint + "|" + group_constraint
+    shell:
+        "samtools merge -@ {threads} {output.merged} {input.primary_sv} {input.supp_sv}"
+
+
+rule GridssAssembleBreakends:
+    threads:
+        64
+    input:
+        ref="results/refs/genome.fasta",
+        idx=rules.bwa_index.output,
+        bams=lambda wc: expand("results/recal/{sample}.sorted.{ending}", sample=get_group_samples(wc), ending=["bam", "bam.bai"]),
+        svs=lambda wc: expand("tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.bam.sv.{ending}", sample=get_group_samples(wc), ending=["bam", "bam.bai"])
+    output:
+        assembly="tmp/group.{group}.bam.gridss.working/group.{group}.bam"
+    conda:
+        "../envs/gridss.yaml"
+    params:
+        jobindex="0",
+        jobnodes="1",
+        working_dir="tmp",
+        picardoptions="",
+        input_args=lambda wc: " ".join(expand("INPUT=results/recal/{sample}.sorted.bam", sample=get_group_samples(wc)))
+    wildcard_constraints:
+        group=group_constraint
+    shell:
+        """
+gridss gridss.AssembleBreakends \
+-Dgridss.gridss.output_to_temp_file=true \
+{jvm_args} \
+-Xmx100g \
+JOB_INDEX={params.jobindex} \
+JOB_NODES={params.jobnodes} \
+TMP_DIR={params.working_dir} \
+WORKING_DIR={params.working_dir} \
+REFERENCE_SEQUENCE={input.ref} \
+WORKER_THREADS={threads} \
+O={output.assembly} \
+{params.input_args} \
+{params.picardoptions} \
+        """
+
+
+rule GridssCollectMetricsGroup:
+    input:
+        assembly="tmp/group.{group}.bam.gridss.working/group.{group}.bam"
+    output:
+        idsv_metrics="tmp/group.{group}.bam.gridss.working/group.{group}.bam.idsv_metrics",
+        mapq_metrics="tmp/group.{group}.bam.gridss.working/group.{group}.bam.mapq_metrics",
+        tag_metrics="tmp/group.{group}.bam.gridss.working/group.{group}.bam.tag_metrics",
+    params:
+        prefix="tmp/group.{group}.bam.gridss.working/group.{group}.bam",
+        working_dir="tmp/group.{group}.bam.gridss.working",
+        maxcoverage=50000,
+        picardoptions="",
+    conda:
+        "../envs/gridss.yaml"
+    wildcard_constraints:
+        group=group_constraint
+    shell:
+        """
+gridss gridss.analysis.CollectGridssMetrics \
+{jvm_args} \
+I={input.assembly} \
+O={params.prefix} \
+THRESHOLD_COVERAGE={params.maxcoverage} \
+TMP_DIR={params.working_dir} \
+FILE_EXTENSION=null \
+GRIDSS_PROGRAM=null \
+GRIDSS_PROGRAM=CollectCigarMetrics \
+GRIDSS_PROGRAM=CollectMapqMetrics \
+GRIDSS_PROGRAM=CollectTagMetrics \
+GRIDSS_PROGRAM=CollectIdsvMetrics \
+GRIDSS_PROGRAM=ReportThresholdCoverage \
+PROGRAM=null \
+PROGRAM=CollectAlignmentSummaryMetrics \
+{params.picardoptions}
+        """
+
+
+rule GridssSoftClipsToSplitReadsAssembly:
+    threads:
+        64
+    input:
+        ref="results/refs/genome.fasta",
+        idx=rules.bwa_index.output,
+        assembly="tmp/group.{group}.bam.gridss.working/group.{group}.bam",
+        idsv_metrics="tmp/group.{group}.bam.gridss.working/group.{group}.bam.idsv_metrics",
+        mapq_metrics="tmp/group.{group}.bam.gridss.working/group.{group}.bam.mapq_metrics",
+        tag_metrics="tmp/group.{group}.bam.gridss.working/group.{group}.bam.tag_metrics",
+    output:
+        assembly_primary_sv="tmp/group.{group}.bam.gridss.working/tmp.group.{group}.bam.sc2sr.primary.sv.bam",
+        assembly_supp_sv="tmp/group.{group}.bam.gridss.working/tmp.group.{group}.bam.sc2sr.supp.sv.bam",
+    params:
+        working_dir="tmp",
+        picardoptions="",
+    conda:
+        "../envs/gridss.yaml"
+    wildcard_constraints:
+        group=group_constraint
+    shell:
+        """
+gridss gridss.SoftClipsToSplitReads \
+{jvm_args} \
+-Xmx50G \
+-Dgridss.async.buffersize=16 \
+-Dsamjdk.create_index=false \
+-Dgridss.gridss.output_to_temp_file=true \
+TMP_DIR={params.working_dir} \
+WORKING_DIR={params.working_dir} \
+REFERENCE_SEQUENCE={input.ref} \
+WORKER_THREADS={threads} \
+I={input.assembly} \
+O={output.assembly_primary_sv} \
+OUTPUT_UNORDERED_RECORDS={output.assembly_supp_sv} \
+REALIGN_ENTIRE_READ=true \
+{params.picardoptions}
+        """
+
+
+rule GridssIdentifyVariants:
+    threads:
+        64
+    input:
+        bams=lambda wc: expand("results/recal/{sample}.sorted.bam", sample=get_group_samples(wc)),
+        assembly_sv="tmp/group.{group}.bam.gridss.working/group.{group}.bam.sv.bam",
+        assembly_sv_index="tmp/group.{group}.bam.gridss.working/group.{group}.bam.sv.bam.bai",
+        assembly="tmp/group.{group}.bam.gridss.working/group.{group}.bam",
+        ref="results/refs/genome.fasta",
+        idx=rules.bwa_index.output,
+    output:
+        unallocated="tmp/group.{group}.vcf.gridss.working/group.{group}.unallocated.vcf"
+    params:
+        input_args=lambda wc: " ".join(expand("INPUT=results/recal/{sample}.sorted.bam", sample=get_group_samples(wc))),
+        working_dir="tmp",
+        picardoptions=""
+    conda:
+        "../envs/gridss.yaml"
+    wildcard_constraints:
+        group=group_constraint
+    shell:
+        """
+gridss gridss.IdentifyVariants \
+-Dgridss.output_to_temp_file=true \
+{jvm_args} \
+-Xmx50g \
+TMP_DIR={params.working_dir} \
+WORKING_DIR={params.working_dir} \
+REFERENCE_SEQUENCE={input.ref} \
+WORKER_THREADS={threads} \
+{params.input_args} \
+ASSEMBLY={input.assembly} \
+OUTPUT_VCF={output.unallocated} \
+        """
+
+rule GridssAnnotateVariants:
+    threads:
+        7
+    input:
+        bams=lambda wc: expand("results/recal/{sample}.sorted.bam", sample=get_group_samples(wc)),
+        assembly_sv="tmp/group.{group}.bam.gridss.working/group.{group}.bam.sv.bam",
+        assembly_sv_index="tmp/group.{group}.bam.gridss.working/group.{group}.bam.sv.bam.bai",
+        unallocated="tmp/group.{group}.vcf.gridss.working/group.{group}.unallocated.vcf",
+        ref="results/refs/genome.fasta",
+        idx=rules.bwa_index.output,
+        assembly="tmp/group.{group}.bam.gridss.working/group.{group}.bam",
+    output:
+        allocated="tmp/group.{group}.vcf.gridss.working/group.{group}.allocated.vcf",
+    params:
+        input_args=lambda wc: " ".join(expand("INPUT=results/recal/{sample}.sorted.bam", sample=get_group_samples(wc))),
+        working_dir="tmp",
+        picardoptions=""
+    conda:
+        "../envs/gridss.yaml"
+    wildcard_constraints:
+        group=group_constraint
+    shell:        """
+gridss gridss.AnnotateVariants \
+-Dgridss.output_to_temp_file=true \
+{jvm_args} \
+-Xmx50g \
+TMP_DIR={params.working_dir} \
+WORKING_DIR={params.working_dir} \
+REFERENCE_SEQUENCE={input.ref} \
+WORKER_THREADS={threads} \
+{params.input_args} \
+ASSEMBLY={input.assembly} \
+INPUT_VCF={input.unallocated} \
+OUTPUT_VCF={output.allocated} \
+{params.picardoptions}
+        """
+
+rule GridssAnnotateUntemplatedSequence:
+    input:
+        allocated="tmp/group.{group}.vcf.gridss.working/group.{group}.allocated.vcf",
+        ref="results/refs/genome.fasta",
+        idx=rules.bwa_index.output,
+    output:
+        vcf="results/gridss_vcf/{group}.vcf"
+    params:
+        working_dir="tmp",
+        picardoptions=""
+    conda:
+        "../envs/gridss.yaml"
+    threads:
+        100
+    shell:
+        """
+gridss gridss.AnnotateUntemplatedSequence \
+-Dgridss.output_to_temp_file=true \
+-Xmx4g \
+{jvm_args} \
+TMP_DIR={params.working_dir} \
+WORKING_DIR={params.working_dir} \
+REFERENCE_SEQUENCE={input.ref} \
+WORKER_THREADS={threads} \
+INPUT={input.allocated} \
+OUTPUT={output.vcf} \
+{params.picardoptions}
+        """

--- a/workflow/rules/gridss.smk
+++ b/workflow/rules/gridss.smk
@@ -235,8 +235,8 @@ rule GridssAssembleBreakends:
     input:
         ref="results/refs/genome.fasta",
         idx=rules.bwa_index.output,
-        bams=lambda wc: expand("results/recal/{sample}.sorted.{ending}", sample=get_group_samples(wc), ending=["bam", "bam.bai"]),
-        svs=lambda wc: expand("tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.bam.sv.{ending}", sample=get_group_samples(wc), ending=["bam", "bam.bai"])
+        bams=lambda wildcards: expand("results/recal/{sample}.sorted.{ending}", sample=get_group_samples(wildcards), ending=["bam", "bam.bai"]),
+        svs=lambda wildcards: expand("tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.bam.sv.{ending}", sample=get_group_samples(wildcards), ending=["bam", "bam.bai"])
     output:
         assembly="tmp/group.{group}.bam.gridss.working/group.{group}.bam"
     conda:
@@ -246,7 +246,7 @@ rule GridssAssembleBreakends:
         jobnodes="1",
         working_dir="tmp",
         picardoptions="",
-        input_args=lambda wc: " ".join(expand("INPUT=results/recal/{sample}.sorted.bam", sample=get_group_samples(wc)))
+        input_args=lambda wildcards: " ".join(expand("INPUT=results/recal/{sample}.sorted.bam", sample=get_group_samples(wildcards)))
     wildcard_constraints:
         group=group_constraint
     shell:
@@ -348,7 +348,7 @@ rule GridssIdentifyVariants:
     threads:
         64
     input:
-        bams=lambda wc: expand("results/recal/{sample}.sorted.bam", sample=get_group_samples(wc)),
+        bams=lambda wildcards: expand("results/recal/{sample}.sorted.bam", sample=get_group_samples(wildcards)),
         assembly_sv="tmp/group.{group}.bam.gridss.working/group.{group}.bam.sv.bam",
         assembly_sv_index="tmp/group.{group}.bam.gridss.working/group.{group}.bam.sv.bam.bai",
         assembly="tmp/group.{group}.bam.gridss.working/group.{group}.bam",
@@ -357,7 +357,7 @@ rule GridssIdentifyVariants:
     output:
         unallocated="tmp/group.{group}.vcf.gridss.working/group.{group}.unallocated.vcf"
     params:
-        input_args=lambda wc: " ".join(expand("INPUT=results/recal/{sample}.sorted.bam", sample=get_group_samples(wc))),
+        input_args=lambda wildcards: " ".join(expand("INPUT=results/recal/{sample}.sorted.bam", sample=get_group_samples(wildcards))),
         working_dir="tmp",
         picardoptions=""
     conda:
@@ -383,7 +383,7 @@ rule GridssAnnotateVariants:
     threads:
         7
     input:
-        bams=lambda wc: expand("results/recal/{sample}.sorted.bam", sample=get_group_samples(wc)),
+        bams=lambda wildcards: expand("results/recal/{sample}.sorted.bam", sample=get_group_samples(wildcards)),
         assembly_sv="tmp/group.{group}.bam.gridss.working/group.{group}.bam.sv.bam",
         assembly_sv_index="tmp/group.{group}.bam.gridss.working/group.{group}.bam.sv.bam.bai",
         unallocated="tmp/group.{group}.vcf.gridss.working/group.{group}.unallocated.vcf",
@@ -393,7 +393,7 @@ rule GridssAnnotateVariants:
     output:
         allocated="tmp/group.{group}.vcf.gridss.working/group.{group}.allocated.vcf",
     params:
-        input_args=lambda wc: " ".join(expand("INPUT=results/recal/{sample}.sorted.bam", sample=get_group_samples(wc))),
+        input_args=lambda wildcards: " ".join(expand("INPUT=results/recal/{sample}.sorted.bam", sample=get_group_samples(wildcards))),
         working_dir="tmp",
         picardoptions=""
     conda:

--- a/workflow/rules/gridss.smk
+++ b/workflow/rules/gridss.smk
@@ -24,7 +24,7 @@ rule GridssCollectMetrics:
         insert_size_metrics="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.insert_size_metrics",
         histogram="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.insert_size_histogram.pdf"
     log:
-        "log/collect_gridss_metrics.{sample}.log"
+        "log/gridss/collect_metrics/{sample}.log"
     params:
         tmp_dir="tmp/{sample}.sorted.bam.gridss.working",
         prefix="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam",
@@ -61,6 +61,8 @@ rule GridssCollectMetricsAndExtractSVReads:
     output:
         sv_metrics="tmp/{sample}.sorted.bam.gridss.working/{sample}.bam.sv_metrics",
         namedsorted_bam="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.namedsorted.bam",
+    log:
+        "log/gridss/collect_metrics_and_extract_sv_reads/{sample}.log"
     params:
         dir="tmp/{sample}.sorted.bam.gridss.working",
         prefix="tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.bam",
@@ -106,7 +108,7 @@ INCLUDE_DUPLICATES=true \
 -Obam \
 -o {output.namedsorted_bam} \
 -@ {threads} \
-/dev/stdin
+/dev/stdin 2> {log}
         """
 
 
@@ -118,7 +120,7 @@ rule GridssComputeSamTags:
     output:
         coordinate_bam="tmp/{sample}.sorted.bam.gridss.working/tmp.{sample}.sorted.bam.coordinate.bam"
     wildcard_constraints:
-        sample=sample_constrain
+        sample=sample_constraint
     params:
         working_dir="tmp",
         tmp_sort="tmp/{sample}.sorted.bam.gridss.working/{sample}.sorted.coordinate-tmp",

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -42,7 +42,7 @@ rule cutadapt_pipe:
     output:
         pipe('pipe/cutadapt/{sample}-{unit}.{fq}.{ending}')
     wildcard_constraints:
-        dataset="fastq|fastq.gz"
+        ending="fastq|fastq.gz"
     threads: 0
     shell:
         "cat {input} > {output}"

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -11,8 +11,8 @@ rule bcf_index:
 
 rule bam_index:
     input:
-        "{prefix}.sorted.bam"
+        "{prefix}.bam"
     output:
-        "{prefix}.sorted.bam.bai"
+        "{prefix}.bam.bai"
     wrapper:
         "0.39.0/bio/samtools/index"


### PR DESCRIPTION
This implements my gridss calling pipeline, which is suppose to replace delly as the structural variant caller. Gridss only calls breakends and varlociraptor does not support breakends yet.  I suggest we should have both callers separately at first by this PR. I would like to implement purple and linx as well, for cnv and fusiongene calling, which both requires gridss. When varlociraptor is modified and able to handle breakends, we should remove delly in a second step.