### PR TITLE
Fixed extract dbnfsp

### DIFF
--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -94,11 +94,9 @@ if is_activated("annotations/dbnsfp"):
             "../envs/htslib.yaml"
         cache: True
         shell:
-            """
-            ((unzip -p {input} "*_variant.chr1.gz" | zcat |
-            head -n 1 ; unzip -p {input} "*_variant.chr*" |
-            zcat | grep -v '^#' ) | bgzip -l9 -@ {threads} > {output}) 2> {log}
-            """
+            "cat <(unzip -p {input} '*_variant.chr1.gz' | zcat | "
+            "head -n 1) <(unzip -p {input} '*_variant.chr*' | "
+            "zcat | grep -v '^#') | bgzip -l9 -@ {threads} > {output} 2> {log}"
     
     rule annotate_dbnsfp:
         threads:


### PR DESCRIPTION
This PR fixes the shell command executed by rule `extract_dbnfsp` failing as it contains a listing which return the exit status of the list.

Thanks to @tedil for solving this.