### PR TITLE
Replace Picard by samtools

### DIFF
--- a/workflow/envs/samtools.yaml
+++ b/workflow/envs/samtools.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - samtools =1.10

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -31,10 +31,12 @@ rule genome_dict:
     output:
         "resources/genome.dict"
     log:
-        "logs/picard/create_dict.log"
+        "logs/samtools/create_dict.log"
+    conda:
+        "../envs/samtools.yaml"
     cache: True
-    wrapper:
-        "0.45.1/bio/picard/createsequencedictionary"
+    shell:
+        "samtools dict {input} > {output} 2> {log} "
 
 
 rule get_known_variants:


### PR DESCRIPTION
This PR replaces Picardtools by samtools for generating the genome dictionary as Picardtools creates an empty one the call. The issue is further explained [here](https://github.com/snakemake-workflows/dna-seq-varlociraptor/issues/16).

Before merging wait until a test run has finished.