### PR TITLE
Parallel annotation

### DIFF
--- a/workflow/envs/snpsift.yaml
+++ b/workflow/envs/snpsift.yaml
@@ -4,3 +4,4 @@ channels:
 dependencies:
   - snpsift =4.3.1
   - bcftools =1.10
+  - pysam =0.15

--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -34,9 +34,10 @@ rule snpeff:
 # TODO What about multiple ID Fields?
 rule annotate_vcfs:
     threads:
-        4
+        100
     input:
         bcf="results/calls/{prefix}.bcf",
+        csi="results/calls/{prefix}.bcf.csi",
         annotations=get_annotation_vcfs(),
         idx=get_annotation_vcfs(idx=True)
     output:
@@ -49,7 +50,7 @@ rule annotate_vcfs:
     conda:
         "../envs/snpsift.yaml"
     shell:
-        "(bcftools view --threads {threads} {input.bcf} {params.pipes} | bcftools view --threads {threads} -Ob > {output}) 2> {log}"
+        "(python ../workflow/scripts/parallel_vcf.py --threads {threads} {input.bcf} '{params.pipes}' | bcftools view --threads {threads} -Ob > {output}) 2> {log}"
 
 
 rule annotate_dgidb:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -159,7 +159,7 @@ annotations = [(e, f) for e, f in config["annotations"]["vcfs"].items() if e != 
 
 def get_annotation_pipes(wildcards, input):
      if annotations:
-         return "| " + " | ".join(
+         return " | ".join(
              ["SnpSift annotate -name {prefix}_ {path} /dev/stdin".format(prefix=prefix, path=path)
               for (prefix, _), path in zip(annotations, input.annotations)]
          )

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -7,8 +7,10 @@ rule bcf_index:
         "logs/bcf-index/{prefix}.log"
     conda:
         "../envs/bcftools.yaml"
+    threads:
+        8
     shell:
-        "bcftools index {input} 2> {log}"
+        "bcftools index --threads {threads} {input} 2> {log}"
 
 
 rule bam_index:

--- a/workflow/scripts/parallel_vcf.py
+++ b/workflow/scripts/parallel_vcf.py
@@ -1,0 +1,50 @@
+import os
+import argparse
+from multiprocessing import Pool
+from pysam import VariantFile
+import tempfile
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument("file_vcf")
+parser.add_argument("command")
+parser.add_argument("--stepsize", "-s", type=int, default=1000000)
+parser.add_argument("--threads", "-t", type=int, default=8)
+parser.add_argument("--tmp", default=None, help="Define the base directory for the tmp files")
+args = parser.parse_args()
+tmp_base = args.tmp
+stepsize = args.stepsize
+
+# create regions
+f = VariantFile(args.file_vcf)
+regions = []
+for name, contig in f.header.contigs.items():
+    last = 0
+    for x in list(range(0, contig.length, stepsize)):
+        stop = min(last + stepsize - 1, contig.length)
+        regions.append(f"{name}:{last}-{stop}")
+        last = stop+1
+f.close() 
+
+#command = "SnpSift annotate {ss_args} {args.database_vcf} /dev/stdin"
+command = args.command
+
+with tempfile.TemporaryDirectory(dir=tmp_base) as t:
+    def f(x):
+        #print("start", x, file=sys.stderr)
+        cmd = f"bcftools view -r {x} {args.file_vcf} | bcftools view -t {x} | {command} | bcftools view -Ob > {t}/{x}.bcf"
+        os.system(cmd)
+        #print("done", x, file=sys.stderr)
+        return f"{t}/{x}.bcf"
+
+    with Pool(args.threads) as p:
+        first = True
+        for filename in p.imap(f, regions):
+            print("merge", filename, file=sys.stderr)
+            if first:
+                cmd = f"bcftools view {filename}"
+            else:
+                cmd = f'bcftools view {filename} | grep -v "#"'
+            os.system(cmd)
+            os.remove(filename)
+            first = False

--- a/workflow/scripts/parallel_vcf.py
+++ b/workflow/scripts/parallel_vcf.py
@@ -10,36 +10,36 @@ parser.add_argument("file_vcf")
 parser.add_argument("command")
 parser.add_argument("--stepsize", "-s", type=int, default=1000000)
 parser.add_argument("--threads", "-t", type=int, default=8)
-parser.add_argument("--tmp", default=None, help="Define the base directory for the tmp files")
+parser.add_argument(
+    "--tmp", default=None, help="Define the base directory for the tmp files"
+)
 args = parser.parse_args()
 tmp_base = args.tmp
 stepsize = args.stepsize
 
 # create regions
-f = VariantFile(args.file_vcf)
-regions = []
-for name, contig in f.header.contigs.items():
-    last = 0
-    for x in list(range(0, contig.length, stepsize)):
-        stop = min(last + stepsize - 1, contig.length)
-        regions.append(f"{name}:{last}-{stop}")
-        last = stop+1
-f.close() 
+with VariantFile(args.file_vcf) as f:
+    regions = []
+    for name, contig in f.header.contigs.items():
+        last = 0
+        for x in list(range(0, contig.length, stepsize)):
+            stop = min(last + stepsize - 1, contig.length)
+            regions.append(f"{name}:{last}-{stop}")
+            last = stop + 1
 
-#command = "SnpSift annotate {ss_args} {args.database_vcf} /dev/stdin"
+# command = "SnpSift annotate {ss_args} {args.database_vcf} /dev/stdin"
 command = args.command
 
-with tempfile.TemporaryDirectory(dir=tmp_base) as t:
-    def f(x):
-        #print("start", x, file=sys.stderr)
-        cmd = f"bcftools view -r {x} {args.file_vcf} | bcftools view -t {x} | {command} | bcftools view -Ob > {t}/{x}.bcf"
+with tempfile.TemporaryDirectory(dir=tmp_base) as tmp_dir:
+
+    def execute_partial(x):
+        cmd = f"bcftools view -r {x} {args.file_vcf} -Ou | bcftools view -t {x} | {command} | bcftools view -Ob > {t}/{x}.bcf"
         os.system(cmd)
-        #print("done", x, file=sys.stderr)
-        return f"{t}/{x}.bcf"
+        return os.path.join(tmp_dir, f"{x}.bcf")
 
     with Pool(args.threads) as p:
         first = True
-        for filename in p.imap(f, regions):
+        for filename in p.imap(execute_partial, regions):
             print("merge", filename, file=sys.stderr)
             if first:
                 cmd = f"bcftools view {filename}"


### PR DESCRIPTION
I've written a script to perform parallelize executions on vcf. This may not be important for WES or other targeted sequencing data, but it is crucial for me. I have a 220gb compressed vcf.gz database and annotating WGS data. This takes days on a single core.
There might be overhead now for targeted sequencing, but testing shows nearly no decrease in runtime for small data.

I would like to keep to keep the script as a standalone script as it is already on my github. I know that
"(python ../workflow/scripts/parallel_vcf.py --threads {threads} {input.bcf} '{params.pipes}' | bcftools view --threads {threads} -Ob > {output}) 2> {log}"
is probably not the way to go here. Can someone tell me a better way of invoking scripts via shell command?

Best
Christo