### PR TITLE
Minor refinements

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -63,6 +63,9 @@ calling:
           - "PRESENT"
         filter: filtername
 
+duplicates:
+  filtering: activate
+
 annotations:
   dbnsfp:
     activate: false

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -63,7 +63,7 @@ calling:
           - "PRESENT"
         filter: filtername
 
-duplicates:
+remove_duplicates:
   activate: true
 
 annotations:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -64,7 +64,7 @@ calling:
         filter: filtername
 
 duplicates:
-  filtering: activate
+  activate: true
 
 annotations:
   dbnsfp:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -61,10 +61,10 @@ def get_cutadapt_input(wildcards):
         return expand("sra/{accession}_{read}.fastq", accession=accession, read=[1, 2])
     if pd.isna(unit["fq2"]):
         # single end local sample
-        return "pipe/cutadapt/{S}-{U}.fq1.fastq{E}".format(S=unit.sample_name, U=unit.unit_name, E=ending)
+        return "pipe/cutadapt/{S}/{U}.fq1.fastq{E}".format(S=unit.sample_name, U=unit.unit_name, E=ending)
     else:
         # paired end local sample
-        return expand("pipe/cutadapt/{S}-{U}.{{read}}.fastq{E}".format(S=unit.sample_name, U=unit.unit_name, E=ending), read=["fq1","fq2"])
+        return expand("pipe/cutadapt/{S}/{U}.{{read}}.fastq{E}".format(S=unit.sample_name, U=unit.unit_name, E=ending), read=["fq1","fq2"])
 
 
 def get_cutadapt_pipe_input(wildcards):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -34,6 +34,20 @@ units = pd.read_csv(config["units"], sep="\t", dtype={"sample_name": str, "unit_
 validate(units, schema="../schemas/units.schema.yaml")
 
 
+def get_recalibrate_quality_bam_input(wildcards):
+    if config["duplicates"]["filtering"] == "activate":
+        return "results/dedup/{}.sorted.bam".format(wildcards.sample)
+    else:
+        return "results/mapped/{}.sorted.bam".format(wildcards.sample)
+
+
+def get_recalibrate_quality_bai_input(wildcards):
+    if config["duplicates"]["filtering"] == "activate":
+        return "results/dedup/{}.sorted.bam.bai".format(wildcards.sample)
+    else:
+        return "results/mapped/{}.sorted.bam.bai".format(wildcards.sample)
+
+
 def get_cutadapt_input(wildcards):
     unit = units.loc[wildcards.sample].loc[wildcards.unit]
     if unit["fq1"].endswith("gz"):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -34,18 +34,12 @@ units = pd.read_csv(config["units"], sep="\t", dtype={"sample_name": str, "unit_
 validate(units, schema="../schemas/units.schema.yaml")
 
 
-def get_recalibrate_quality_bam_input(wildcards):
+def get_recalibrate_quality_input(wildcards, bai=False):
+    ext = ".bai" if bai else ""
     if is_activated("duplicate_filtering"):
-        return "results/dedup/{}.sorted.bam".format(wildcards.sample)
+        return "results/dedup/{}.sorted.bam{}".format(wildcards.sample, ext)
     else:
-        return "results/mapped/{}.sorted.bam".format(wildcards.sample)
-
-
-def get_recalibrate_quality_bai_input(wildcards):
-    if is_activated("duplicate_filtering"):
-        return "results/dedup/{}.sorted.bam.bai".format(wildcards.sample)
-    else:
-        return "results/mapped/{}.sorted.bam.bai".format(wildcards.sample)
+        return "results/mapped/{}.sorted.bam{}".format(wildcards.sample, ext)
 
 
 def get_cutadapt_input(wildcards):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -36,7 +36,7 @@ validate(units, schema="../schemas/units.schema.yaml")
 
 def get_recalibrate_quality_input(wildcards, bai=False):
     ext = ".bai" if bai else ""
-    if is_activated("duplicate_filtering"):
+    if is_activated("remove_duplicates"):
         return "results/dedup/{}.sorted.bam{}".format(wildcards.sample, ext)
     else:
         return "results/mapped/{}.sorted.bam{}".format(wildcards.sample, ext)

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -35,14 +35,14 @@ validate(units, schema="../schemas/units.schema.yaml")
 
 
 def get_recalibrate_quality_bam_input(wildcards):
-    if config["duplicates"]["filtering"] == "activate":
+    if is_activated("duplicate_filtering"):
         return "results/dedup/{}.sorted.bam".format(wildcards.sample)
     else:
         return "results/mapped/{}.sorted.bam".format(wildcards.sample)
 
 
 def get_recalibrate_quality_bai_input(wildcards):
-    if config["duplicates"]["filtering"] == "activate":
+    if is_activated("duplicate_filtering"):
         return "results/dedup/{}.sorted.bam.bai".format(wildcards.sample)
     else:
         return "results/mapped/{}.sorted.bam.bai".format(wildcards.sample)

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -33,7 +33,7 @@ rule mark_duplicates:
 rule recalibrate_base_qualities:
     input:
         bam=get_recalibrate_quality_input,
-        bai=lambda wc, _: get_recalibrate_quality_input(wc, True),
+        bai=lambda wc: get_recalibrate_quality_input(wc, True),
         ref="resources/genome.fasta",
         ref_dict="resources/genome.dict",
         ref_fai="resources/genome.fasta.fai",

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -33,7 +33,7 @@ rule mark_duplicates:
 rule recalibrate_base_qualities:
     input:
         bam=get_recalibrate_quality_input,
-        bai=lambda wc: get_recalibrate_quality_input(wc, True),
+        bai=lambda w: get_recalibrate_quality_input(w, bai=True),
         ref="resources/genome.fasta",
         ref_dict="resources/genome.dict",
         ref_fai="resources/genome.fasta.fai",

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -16,6 +16,17 @@ rule map_reads:
         "0.39.0/bio/bwa/mem"
 
 
+rule index_reads:
+    input: 
+        "results/mapped/{sample}.sorted.bam"
+    output:
+        "results/mapped/{sample}.sorted.bam.bai"
+    conda:
+        "../envs/samtools.yaml"
+    shell:
+        "samtools index {input}"
+
+
 rule mark_duplicates:
     input:
         "results/mapped/{sample}.sorted.bam"
@@ -32,8 +43,8 @@ rule mark_duplicates:
 
 rule recalibrate_base_qualities:
     input:
-        bam="results/dedup/{sample}.sorted.bam",
-        bai="results/dedup/{sample}.sorted.bam.bai",
+        bam=get_recalibrate_quality_bam_input,
+        bai=get_recalibrate_quality_bai_input,
         ref="resources/genome.fasta",
         ref_dict="resources/genome.dict",
         ref_fai="resources/genome.fasta.fai",

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -16,17 +16,6 @@ rule map_reads:
         "0.39.0/bio/bwa/mem"
 
 
-rule index_reads:
-    input: 
-        "results/mapped/{sample}.sorted.bam"
-    output:
-        "results/mapped/{sample}.sorted.bam.bai"
-    conda:
-        "../envs/samtools.yaml"
-    shell:
-        "samtools index {input}"
-
-
 rule mark_duplicates:
     input:
         "results/mapped/{sample}.sorted.bam"

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -32,8 +32,8 @@ rule mark_duplicates:
 
 rule recalibrate_base_qualities:
     input:
-        bam=get_recalibrate_quality_bam_input,
-        bai=get_recalibrate_quality_bai_input,
+        bam=get_recalibrate_quality_input,
+        bai=lambda wc, _: get_recalibrate_quality_input(wc, True),
         ref="resources/genome.fasta",
         ref_dict="resources/genome.dict",
         ref_fai="resources/genome.fasta.fai",

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -12,7 +12,7 @@ rule cutadapt_pipe:
     input:
         get_cutadapt_pipe_input
     output:
-        pipe('pipe/cutadapt/{sample}-{unit}.{fq}.{ext}')
+        pipe('pipe/cutadapt/{sample}/{unit}.{fq}.{ext}')
     log:
         "logs/pipe-fastqs/{sample}-{unit}.{fq}.{ext}"
     wildcard_constraints:
@@ -26,9 +26,9 @@ rule cutadapt_pe:
     input:
         get_cutadapt_input
     output:
-        fastq1="results/trimmed/{sample}-{unit}.1.fastq.gz",
-        fastq2="results/trimmed/{sample}-{unit}.2.fastq.gz",
-        qc="results/trimmed/{sample}-{unit}.paired.qc.txt"
+        fastq1="results/trimmed/{sample}/{unit}.1.fastq.gz",
+        fastq2="results/trimmed/{sample}/{unit}.2.fastq.gz",
+        qc="results/trimmed/{sample}/{unit}.paired.qc.txt"
     log:
         "logs/cutadapt/{sample}-{unit}.log"
     params:
@@ -42,8 +42,8 @@ rule cutadapt_se:
     input:
         get_cutadapt_input
     output:
-        fastq="results/trimmed/{sample}-{unit}.single.fastq.gz",
-        qc="results/trimmed/{sample}-{unit}.single.qc.txt"
+        fastq="results/trimmed/{sample}/{unit}.single.fastq.gz",
+        qc="results/trimmed/{sample}/{unit}.single.qc.txt"
     log:
         "logs/cutadapt/{sample}-{unit}.log"
     params:
@@ -55,7 +55,7 @@ rule cutadapt_se:
 
 rule merge_fastqs:
     input:
-        lambda w: expand("results/trimmed/{{sample}}-{unit}.{{read}}.fastq.gz", unit=units.loc[w.sample, "unit_name"])
+        lambda w: expand("results/trimmed/{{sample}}/{unit}.{{read}}.fastq.gz", unit=units.loc[w.sample, "unit_name"])
     output:
         "results/merged/{sample}.{read}.fastq.gz"
     log:

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -117,7 +117,7 @@ properties:
       - filter
       - fdr-control
   
-  duplicate_filtering:
+  remove_duplicates:
     type: object
     properties:
       activate:

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -117,6 +117,12 @@ properties:
       - filter
       - fdr-control
   
+  duplicate_filtering:
+    type: object
+    properties:
+      activate:
+        type: boolean
+
   annotations:
     type: object
     properties:


### PR DESCRIPTION
This PR contains two minor changes:

Cutadapt input is now places into a subfolder "sample/unit...". Using `-` as separator may confuse snakemake when deriving the wildcards.

Mark Duplicates is now optional and can now be changed in the config file.