### PR TITLE
Replace trimmomatic by ptrimmer

### DIFF
--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -20,11 +20,8 @@ ref:
 primers:
   trimming:
     activate: false
-    trimmomatic:
-      fasta: "path/to/fasta"
-      seed_mismatch: 1 # recommendation: 1-2
-      palindrom_threshold: 30 # recommendation: range of 30
-      simple_clip_threshold: 7 # recommendation: 7 to 15
+    primers: "path/to/primers-txt"
+
 
 # Estimation of tumor mutational burden.
 tmb:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,6 +21,8 @@ ref:
 primers:
   trimming:
     activate: false
+    # path to amplicon file in the format defined by ptrimmer:
+    # https://github.com/DMU-lilab/pTrimmer
     primers: "path/to/primer-txt"
 
 # Estimation of tumor mutational burden.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,11 +21,7 @@ ref:
 primers:
   trimming:
     activate: false
-    trimmomatic:
-      fasta: "path/to/fasta"
-      seed_mismatch: 1 # recommendation: 1-2
-      palindrom_threshold: 30 # recommendation: range of 30
-      simple_clip_threshold: 7 # recommendation: 7 to 15
+    primers: "path/to/primer-txt"
 
 # Estimation of tumor mutational burden.
 tmb:

--- a/workflow/envs/ptrimmer.yaml
+++ b/workflow/envs/ptrimmer.yaml
@@ -1,0 +1,5 @@
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - ptrimmer =1.3

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -79,9 +79,9 @@ def is_paired_end(sample):
 
 def get_map_reads_input(wildcards):
     if is_paired_end(wildcards.sample):
-        return ["results/merged/{sample}.1.fastq.gz",
-                "results/merged/{sample}.2.fastq.gz"]
-    return "results/merged/{sample}.single.fastq.gz"
+        return ["results/merged/{sample}_R1.fastq.gz",
+                "results/merged/{sample}_R2.fastq.gz"]
+    return "results/merged/{sample}_single.fastq.gz"
 
 def get_group_aliases(wildcards):
     return samples.loc[samples["group"] == wildcards.group]["alias"]
@@ -201,5 +201,6 @@ def get_tabix_params(wildcards):
 
 
 def get_trimmed_fastqs(wc):
+    print()
     subdir = "primers" if is_activated("primers/trimming") else "adapters"
-    return expand("results/trimmed/{subdir}/{sample}/{unit}.{read}.fastq.gz", subdir=subdir, unit=units.loc[wc.sample, "unit_name"], sample=wc.sample, read=wc.read)
+    return expand("results/trimmed/{subdir}/{sample}/{unit}_{read}.fastq.gz", subdir=subdir, unit=units.loc[wc.sample, "unit_name"], sample=wc.sample, read=wc.read)

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -71,7 +71,7 @@ rule pipe_ptrimmer_pe:
     output:
         pipe("results/trimmed/adapters/{sample}/{unit}.paired_R{read}.fastq.gz")
     log:
-        "logs/pipe-fastqs/catadapt/{sample}-{unit}.{read}.{log}"
+        "logs/pipe-fastqs/catadapt/{sample}-{unit}.{read}.log"
     threads: 0 # this does not need CPU
     shell:
         "cat {input} > {output} 2> {log}"

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -14,7 +14,7 @@ rule cutadapt_pipe:
     output:
         pipe('pipe/cutadapt/{sample}/{unit}.{fq}.{ext}')
     log:
-        "logs/pipe-fastqs/{sample}-{unit}.{fq}.{ext}"
+        "logs/pipe-fastqs/catadapt/{sample}-{unit}.{fq}.{ext}"
     wildcard_constraints:
         ext=r"fastq|fastq\.gz"
     threads: 0 # this does not need CPU
@@ -58,6 +58,8 @@ rule pipe_ptrimmer_se:
         "results/trimmed/adapters/{sample}/{unit}.single.fastq.gz"
     output:
         pipe("results/trimmed/adapters/{sample}/{unit}.single_R1.fastq.gz")
+    log:
+        "logs/pipe-fastqs/ptrimmer/{sample}-{unit}.single.log"
     threads: 0 # this does not need CPU
     shell:
         "cat {input} > {output} 2> {log}"
@@ -68,6 +70,8 @@ rule pipe_ptrimmer_pe:
         "results/trimmed/adapters/{sample}/{unit}.{read}.fastq.gz"
     output:
         pipe("results/trimmed/adapters/{sample}/{unit}.paired_R{read}.fastq.gz")
+    log:
+        "logs/pipe-fastqs/catadapt/{sample}-{unit}.{read}.{log}"
     threads: 0 # this does not need CPU
     shell:
         "cat {input} > {output} 2> {log}"

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -80,18 +80,17 @@ rule ptrimmer_se:
     input:
         "results/trimmed/adapters/{sample}/{unit}.single_R1.fastq.gz"
     output:
-        "results/trimmed/primers/{sample}/{unit}.single_trim_R1.fastq.gz",
+        "results/trimmed/primers/{sample}/{unit}.single.fastq.gz",
     log:
         "logs/ptrimmer/{sample}-{unit}.log"
     params:
         primers=config["primers"]["trimming"]["primers"],
-        tmp_fq="results/trimmed/adapters/{sample}/{unit}.single_trim_R1.fq",
-        folder=lambda wc, output: os.path.dirname(output)
+
     conda:
         "../envs/ptrimmer.yaml"
     shell:
-        "ptrimmer -f {input} -a {params.primers} -o {params.folder}"
-        "gzip -c {params.tmp_fq} > {output}"
+        "ptrimmer -f {input} -a {params.primers} -o ./ > {log}"
+        "gzip -c results/trimmed/adapters/{wildcards.sample}/{wildcards.unit}.single_trim_R1.fq > {output}"
 
 
 rule ptrimmer_pe:
@@ -104,14 +103,11 @@ rule ptrimmer_pe:
     log:
         "logs/ptrimmer/{sample}-{unit}.log"
     params:
-        primers=config["primers"]["trimming"]["primers"],
-        tmp_fq1="results/trimmed/adapters/{sample}/{unit}.paired_trim_R1.fq",
-        tmp_fq2="results/trimmed/adapters/{sample}/{unit}.paired_trim_R2.fq",
-        folder=lambda wc, output: os.path.dirname(output.fastq1)
+        primers=config["primers"]["trimming"]["primers"]
     shell:
-        "ptrimmer -f {input.r1} -r {input.r2} -a {params.primers} -o {params.folder}"
-        "gzip -c {params.tmp_fq1} > {output.fastq1}"
-        "gzip -c {params.tmp_fq2} > {output.fastq2}"
+        "ptrimmer -f {input.r1} -r {input.r2} -a {params.primers} -o ./ > {log}"
+        "gzip -c results/trimmed/adapters/{wildcards.sample}/{wildcards.unit}.paired_trim_R1.fq > {output.fastq1}"
+        "gzip -c results/trimmed/adapters/{{wildcards.sample}}/{wildcards.unit}.paired_trim_R2.fq > {output.fastq2}"
 
 
 rule merge_fastqs:

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -53,6 +53,7 @@ rule cutadapt_se:
     wrapper:
         "0.42.0/bio/cutadapt/se"
 
+#TODO Remove rule and set input of ptrimmer_se to unit_R1 (patch pTrimmer)
 rule pipe_ptrimmer_se:
     input:
         "results/trimmed/adapters/{sample}/{unit}.single.fastq.gz"

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -26,8 +26,8 @@ rule cutadapt_pe:
     input:
         get_cutadapt_input
     output:
-        fastq1="results/trimmed/adapters/{sample}/{unit}.1.fastq.gz",
-        fastq2="results/trimmed/adapters/{sample}/{unit}.2.fastq.gz",
+        fastq1="results/trimmed/adapters/{sample}/{unit}_R1.fastq.gz",
+        fastq2="results/trimmed/adapters/{sample}/{unit}_R2.fastq.gz",
         qc="results/trimmed/adapters/{sample}/{unit}.paired.qc.txt"
     log:
         "logs/cutadapt/{sample}-{unit}.log"
@@ -65,17 +65,6 @@ rule pipe_ptrimmer_se:
         "cat {input} > {output} 2> {log}"
 
 
-rule pipe_ptrimmer_pe:
-    input:
-        "results/trimmed/adapters/{sample}/{unit}.{read}.fastq.gz"
-    output:
-        pipe("results/trimmed/adapters/{sample}/{unit}.paired_R{read}.fastq.gz")
-    log:
-        "logs/pipe-fastqs/catadapt/{sample}-{unit}.{read}.log"
-    threads: 0 # this does not need CPU
-    shell:
-        "cat {input} > {output} 2> {log}"
-
 rule ptrimmer_se:
     input:
         "results/trimmed/adapters/{sample}/{unit}.single_R1.fastq.gz"
@@ -95,11 +84,11 @@ rule ptrimmer_se:
 
 rule ptrimmer_pe:
     input:
-        r1="results/trimmed/adapters/{sample}/{unit}.paired_R1.fastq.gz",
-        r2="results/trimmed/adapters/{sample}/{unit}.paired_R2.fastq.gz",
+        r1="results/trimmed/adapters/{sample}/{unit}_R1.fastq.gz",
+        r2="results/trimmed/adapters/{sample}/{unit}_R2.fastq.gz",
     output:
-        fastq1="results/trimmed/primers/{sample}/{unit}.1.fastq.gz",
-        fastq2="results/trimmed/primers/{sample}/{unit}.2.fastq.gz",
+        fastq1="results/trimmed/primers/{sample}/{unit}_R1.fastq.gz",
+        fastq2="results/trimmed/primers/{sample}/{unit}_R2.fastq.gz",
     log:
         "logs/ptrimmer/{sample}-{unit}.log"
     params:
@@ -114,10 +103,10 @@ rule merge_fastqs:
     input:
         get_trimmed_fastqs
     output:
-        "results/merged/{sample}.{read}.fastq.gz"
+        "results/merged/{sample}_{read}.fastq.gz"
     log:
-        "logs/merge-fastqs/{sample}.{read}.log"
+        "logs/merge-fastqs/{sample}_{read}.log"
     wildcard_constraints:
-        read="single|1|2"
+        read="single|R1|R2"
     shell:
         "cat {input} > {output} 2> {log}"

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -53,17 +53,9 @@ properties:
         properties:
           activate: 
             type: boolean
-          trimmomatic:
-            type: object
-            properties:
-              fasta:
-                type: string
-              seed_mismatch:
-                type: number
-              palindrom_threshold:
-                type: number
-              simple_clip_threshold:
-                type: number
+          primers:
+            type: string
+
 
   oncoprint:
     type: object


### PR DESCRIPTION
This PR replaces trimmomatic by ptrimmer, as trimming primers using trimmomatic did not work as expected.

Additionally I had to add pipes as pTrimmer asks for input files containing "_R1" and "_R2"-string in the file names.