### PR TITLE
Fixing pTrimmer rules

### DIFF
--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -99,8 +99,8 @@ rule ptrimmer_pe:
         "../envs/ptrimmer.yaml"
     shell:
         "ptrimmer -s pair -f {input.r1} -r {input.r2} -a {params.primers} -o {params.output_dir} &> {log} && "
-        "(gzip -c -9 results/trimmed/primers/{wildcards.sample}/{wildcards.unit}_trim_R1.fq > {output.r1} & "
-        "gzip -c -9 results/trimmed/primers/{wildcards.sample}/{wildcards.unit}_trim_R2.fq > {output.r2})"
+        "gzip -c -9 results/trimmed/primers/{wildcards.sample}/{wildcards.unit}_trim_R1.fq > {output.r1} && "
+        "gzip -c -9 results/trimmed/primers/{wildcards.sample}/{wildcards.unit}_trim_R2.fq > {output.r2}"
 
 
 

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -80,7 +80,8 @@ rule ptrimmer_se:
         "../envs/ptrimmer.yaml"
     shell:
         "ptrimmer -s single -f {input} -a {params.primers} -o {params.output_dir} &> {log} && "
-        "gzip -c results/trimmed/primers/{wildcards.sample}/{wildcards.unit}.single_trim_R1.fq > {output}"
+        "gzip -c results/trimmed/primers/{wildcards.sample}/{wildcards.unit}.single_trim_R1.fq > {output} && "
+        "rm gzip -c results/trimmed/primers/{wildcards.sample}/{wildcards.unit}.single_trim_R1.fq"
 
 
 rule ptrimmer_pe:
@@ -100,7 +101,9 @@ rule ptrimmer_pe:
     shell:
         "ptrimmer -s pair -f {input.r1} -r {input.r2} -a {params.primers} -o {params.output_dir} &> {log} && "
         "gzip -c -9 results/trimmed/primers/{wildcards.sample}/{wildcards.unit}_trim_R1.fq > {output.r1} && "
-        "gzip -c -9 results/trimmed/primers/{wildcards.sample}/{wildcards.unit}_trim_R2.fq > {output.r2}"
+        "gzip -c -9 results/trimmed/primers/{wildcards.sample}/{wildcards.unit}_trim_R2.fq > {output.r2} && "
+        "rm results/trimmed/primers/{wildcards.sample}/{wildcards.unit}_trim_R1.fq && "
+        "rm results/trimmed/primers/{wildcards.sample}/{wildcards.unit}_trim_R2.fq"
 
 
 

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -100,7 +100,7 @@ rule ptrimmer_pe:
     shell:
         "ptrimmer -s pair -f {input.r1} -r {input.r2} -a {params.primers} -o {params.output_dir} &> {log} && "
         "(gzip -c -9 results/trimmed/primers/{wildcards.sample}/{wildcards.unit}_trim_R1.fq > {output.r1} & "
-        "gzip -c -9 results/trimmed/primers/{wildcards.sample}/{wildcards.unit}_trim_R2.fq > {output.r1})"
+        "gzip -c -9 results/trimmed/primers/{wildcards.sample}/{wildcards.unit}_trim_R2.fq > {output.r2})"
 
 
 

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -81,7 +81,7 @@ rule ptrimmer_se:
     shell:
         "ptrimmer -s single -f {input} -a {params.primers} -o {params.output_dir} &> {log} && "
         "gzip -c results/trimmed/primers/{wildcards.sample}/{wildcards.unit}.single_trim_R1.fq > {output} && "
-        "rm -c results/trimmed/primers/{wildcards.sample}/{wildcards.unit}.single_trim_R1.fq"
+        "rm results/trimmed/primers/{wildcards.sample}/{wildcards.unit}.single_trim_R1.fq"
 
 
 rule ptrimmer_pe:

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -81,7 +81,7 @@ rule ptrimmer_se:
     shell:
         "ptrimmer -s single -f {input} -a {params.primers} -o {params.output_dir} &> {log} && "
         "gzip -c results/trimmed/primers/{wildcards.sample}/{wildcards.unit}.single_trim_R1.fq > {output} && "
-        "rm gzip -c results/trimmed/primers/{wildcards.sample}/{wildcards.unit}.single_trim_R1.fq"
+        "rm -c results/trimmed/primers/{wildcards.sample}/{wildcards.unit}.single_trim_R1.fq"
 
 
 rule ptrimmer_pe:


### PR DESCRIPTION
This PR fixes serveral issues causing ptrimmer to fail.

Fixes:

- Wrong output path where gzip can not find input file
- Missing `-s` parameter
- Concatenating of ptrimmer and gzip commands

Improvements:

- Higher compression rate
- Writing stdout and stderr to log-file

Current issues:

- [x] Remove files created by ptrimmer after compression
- [x] `merge_fastqs` seems to be called before both gzip processes have been finished

Currently files created by ptrimmer still exist after compression as writing to stdout keeps the original file. Does anyone know how to remove those without doing so manually?

Should we add two threads as there are two gzip processes?

More about it seems like `merge_fastqs` is called before both gzip processes have been finished as bwa crashes. The issue here is, that one of the merged fastq-mates has an unexpected `end-of-file` error while the the trimmed fastqs are fine. After deleting the merge fastqs the issue is solved as merging runs on the now finished trimmed fastqs. 