### PR TITLE
Replaced snpeff download by wrapper

### DIFF
--- a/workflow/envs/snpeff.yaml
+++ b/workflow/envs/snpeff.yaml
@@ -1,6 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-dependencies:
-  - snpeff =4.3.1t
-

--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -1,16 +1,13 @@
-rule download_snpeff_db:
+rule snpeff_download:
     output:
-        directory("resources/snpeff/{ref}")
+        directory("resources/snpeff/{reference}")
     log:
-        "logs/download-snpeff-db/{ref}.log"
+        "logs/snpeff/download/{reference}.log"
     params:
-        db_dir=lambda _, output: str(Path(output[0]).parent.resolve()),
-        ref="{ref}"
-    conda:
-        "../envs/snpeff.yaml"
+        reference="{reference}"
     cache: True
-    shell:
-        "snpEff download -dataDir {params.db_dir} {params.ref} 2> {log}"
+    wrapper:
+        "0.52.0/bio/snpeff/download"
 
 rule snpeff:
     input:

--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -20,13 +20,11 @@ rule snpeff:
     log:
         "logs/snpeff/{group}.log"
     params:
-        reference="{build}.{snpeff_release}".format(**config["ref"]),
-        data_dir=lambda _, input: Path(input.db).parent.resolve(),
         extra="-Xmx4g -nodownload"
     resources:
         mem_mb=4000
     wrapper:
-        "0.50.4/bio/snpeff"
+        "0.52.0/bio/snpeff"
 
 # TODO What about multiple ID Fields?
 rule annotate_vcfs:

--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -24,7 +24,7 @@ rule snpeff:
     resources:
         mem_mb=4000
     wrapper:
-        "0.52.0/bio/snpeff"
+        "0.52.0/bio/snpeff/annotate"
 
 # TODO What about multiple ID Fields?
 rule annotate_vcfs:

--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -13,7 +13,7 @@ rule freebayes:
         extra=config["params"].get("freebayes", ""),
     threads: 100 # use all available cores for calling
     wrapper:
-        "0.51.3/bio/freebayes"
+        "0.52.0/bio/freebayes"
 
 
 rule delly:


### PR DESCRIPTION
As the title says the rule `snpeff_download` get's replaced by the snpeff wrapper.
More about, the freebayes wrapper is updated to the latest version using a cleaner regex. 