### PR TITLE
Fix known variants

### DIFF
--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -7,7 +7,7 @@ rule snpeff_download:
         reference="{reference}"
     cache: True
     wrapper:
-        "0.52.0/bio/snpeff/download"
+        "0.55.1/bio/snpeff/download"
 
 rule snpeff:
     input:
@@ -24,7 +24,7 @@ rule snpeff:
     resources:
         mem_mb=4000
     wrapper:
-        "0.52.0/bio/snpeff/annotate"
+        "0.55.1/bio/snpeff/annotate"
 
 # TODO What about multiple ID Fields?
 rule annotate_vcfs:

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -63,4 +63,4 @@ rule bcftools_concat:
     params:
         "-a -Ob" # TODO Check this
     wrapper:
-        "0.50.1/bio/bcftools/concat"
+        "0.55.1/bio/bcftools/concat"

--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -13,7 +13,7 @@ rule freebayes:
         extra=config["params"].get("freebayes", ""),
     threads: 100 # use all available cores for calling
     wrapper:
-        "0.52.0/bio/freebayes"
+        "0.55.1/bio/freebayes"
 
 
 rule delly:
@@ -30,4 +30,4 @@ rule delly:
         extra=config["params"].get("delly", "")
     threads: lambda _, input: len(input.samples) # delly parallelizes over the number of samples
     wrapper:
-        "0.43.0/bio/delly"
+        "0.55.1/bio/delly"

--- a/workflow/rules/filtering.smk
+++ b/workflow/rules/filtering.smk
@@ -41,4 +41,4 @@ rule merge_calls:
     params:
         "-a -Ob"
     wrapper:
-        "0.50.1/bio/bcftools/concat"
+        "0.55.1/bio/bcftools/concat"

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -13,7 +13,7 @@ rule map_reads:
         sort_order="coordinate"
     threads: 8
     wrapper:
-        "0.39.0/bio/bwa/mem"
+        "0.55.1/bio/bwa/mem"
 
 
 rule mark_duplicates:
@@ -27,7 +27,7 @@ rule mark_duplicates:
     params:
         config["params"]["picard"]["MarkDuplicates"]
     wrapper:
-        "0.39.0/bio/picard/markduplicates"
+        "0.55.1/bio/picard/markduplicates"
 
 
 rule recalibrate_base_qualities:
@@ -46,4 +46,4 @@ rule recalibrate_base_qualities:
     params:
         extra=config["params"]["gatk"]["BaseRecalibrator"]
     wrapper:
-        "0.47.0/bio/gatk/baserecalibrator"
+        "0.55.1/bio/gatk/baserecalibrator"

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -50,6 +50,7 @@ rule get_known_variants:
     params:
         species=config["ref"]["species"],
         release=config["ref"]["release"],
+        build=config["ref"]["build"]
         type="all"
     cache: True
     wrapper:

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -50,7 +50,7 @@ rule get_known_variants:
     params:
         species=config["ref"]["species"],
         release=config["ref"]["release"],
-        build=config["ref"]["build"]
+        build=config["ref"]["build"],
         type="all"
     cache: True
     wrapper:

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -19,7 +19,7 @@ rule bam_index:
     log:
         "logs/bam-index/{prefix}.log"
     wrapper:
-        "0.39.0/bio/samtools/index"
+        "0.55.1/bio/samtools/index"
 
 
 rule tabix_known_variants:
@@ -33,7 +33,7 @@ rule tabix_known_variants:
         get_tabix_params
     cache: True
     wrapper:
-        "0.45.1/bio/tabix"
+        "0.55.1/bio/tabix"
 
 
 rule get_covered_regions:


### PR DESCRIPTION
This PR fixes the current workflow as `get_known_variants` fails due to a missing `build` parameter.

Additionally, all wrappers are updated to `0.55.1`.