### PR TITLE
Filter mapped primers

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -99,7 +99,7 @@ def get_group_bams(wildcards):
 
 def get_regions():
     if is_activated("primers/trimming"):
-        return "results/primers/target_regions.bed"
+        return "results/primers/target_regions.merged.bed"
     else:
         return []
 

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -86,7 +86,7 @@ rule build_target_regions:
     output:
         "results/primers/target_regions.bed"
     log:
-        "/logs/primers/build_target_regions.log"
+        "logs/primers/build_target_regions.log"
     script:
         "../scripts/build_target_regions.py"
 

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -68,24 +68,45 @@ rule get_primer_insert:
         "../scripts/extract_primers_insert.py"
 
 
-rule get_primer_interval:
+rule primer_to_bedpe:
     input:
         "results/mapped/primers.bam"
     output:
-        "results/primers/target_regions.bed"
+        "results/primers/primers.bedpe"
     log:
         "logs/primers/target_regions.log"
     conda:
         "../envs/bedtools.yaml"
     shell:
-        "samtools sort -n {input} | bamToBed -i - -bedpe | "
-        "cut -f 1,2,6 | "
-        "sort -k1,1 -k2,2n | mergeBed -i - > {output}"
+        "samtools sort -n {input} | bamToBed -i - -bedpe > {output} 2> {log}"
+
+rule build_target_regions:
+    input:
+        "results/primers/primers.bedpe"
+    output:
+        "results/primers/target_regions.bed"
+    log:
+        "/logs/primers/build_target_regions.log"
+    script:
+        "../scripts/build_target_regions.py"
+
+
+rule merge_target_regions:
+    input:
+        "results/primers/target_regions.bed"
+    output:
+        "results/primers/target_regions.merged.bed"
+    log:
+        "logs/primers/merge_target_regions.log"
+    conda:
+        "../envs/bedtools.yaml"
+    shell:
+        "sort -k1,1 -k2,2n {input} | mergeBed -i - > {output} 2> {log}"
 
 
 rule build_excluded_regions:
     input:
-        target_regions="results/primers/target_regions.bed",
+        target_regions="results/primers/target_regions.merged.bed",
         genome_index = "resources/genome.fasta.fai"
     output:
         "results/primers/excluded_regions.bed"

--- a/workflow/scripts/build_target_regions.py
+++ b/workflow/scripts/build_target_regions.py
@@ -1,20 +1,24 @@
+import pandas as pd
+
 log_file = open(snakemake.log[0], "w")
 out = open(snakemake.output[0], "w")
 
-with open(snakemake.input[0], "r") as primer_file:
-    for line in primer_file.readlines():
-        line = line.strip().split("\t")
-        chr_1 = line[0]
-        chr_2 = line[3]
-        if chr_1 == chr_2:
-            print(
-                "{chr}\t{start}\t{end}".format(chr=chr_1, start=line[1], end=line[5]),
-                file=out,
-            )
-        else:
-            print(
-                "{primer}\t{chr1}\t{chr2}".format(
-                    primer=line[6], chr1=chr_1, chr2=chr_2
-                ),
-                file=log_file,
-            )
+chunksize = 10 ** 6
+for data_primers in pd.read_csv(
+    snakemake.input[0],
+    sep="\t",
+    header=None,
+    chunksize=chunksize,
+    usecols=[0, 1, 3, 5, 6],
+):
+    valid_primers = data_primers[0] == data_primers[3]
+    print(
+        data_primers[valid_primers]
+        .drop(columns=[3, 6])
+        .to_csv(sep="\t", index=False, header=False),
+        file=out,
+    )
+    print(
+        data_primers[~valid_primers].to_csv(sep="\t", index=False, header=False),
+        file=log_file,
+    )

--- a/workflow/scripts/build_target_regions.py
+++ b/workflow/scripts/build_target_regions.py
@@ -1,0 +1,12 @@
+log_file=open(snakemake.log[0], 'w')
+out=open(snakemake.output[0], 'w')
+
+with open(snakemake.input[0], 'r') as primer_file:
+    for line in primer_file.readlines():
+        line = line.strip().split("\t")
+        chr_1 = line[0]
+        chr_2 = line[1]
+        if chr_1 == chr_2:
+            print("{chr}\t{start}\t{end}".format(chr=chr_1, start=line[1], end=line[5]), file=out)
+        else:
+            print("{primer}\t{chr1}\t{chr2}".format(primer=line[6],chr1=chr_1, chr2=chr_2), file=log_file)

--- a/workflow/scripts/build_target_regions.py
+++ b/workflow/scripts/build_target_regions.py
@@ -5,7 +5,7 @@ with open(snakemake.input[0], "r") as primer_file:
     for line in primer_file.readlines():
         line = line.strip().split("\t")
         chr_1 = line[0]
-        chr_2 = line[1]
+        chr_2 = line[3]
         if chr_1 == chr_2:
             print(
                 "{chr}\t{start}\t{end}".format(chr=chr_1, start=line[1], end=line[5]),

--- a/workflow/scripts/build_target_regions.py
+++ b/workflow/scripts/build_target_regions.py
@@ -1,26 +1,25 @@
 import pandas as pd
 
-log_file = open(snakemake.log[0], "w")
-out = open(snakemake.output[0], "w")
-
 chunksize = 10 ** 6
-for data_primers in pd.read_csv(
-    snakemake.input[0],
-    sep="\t",
-    header=None,
-    chunksize=chunksize,
-    usecols=[0, 1, 3, 5, 6],
-):
-    valid_primers = data_primers[0] == data_primers[3]
-    print(
-        data_primers[valid_primers]
-        .drop(columns=[3, 6])
-        .to_csv(sep="\t", index=False, header=False),
-        file=out,
-    )
-    print(
-        data_primers[~valid_primers].to_csv(sep="\t", index=False, header=False),
-        file=log_file,
-    )
-log_file.close()
-out.close()
+with open(snakemake.output[0], "w") as out:
+    with open(snakemake.log[0], "w") as log_file:
+        for data_primers in pd.read_csv(
+            snakemake.input[0],
+            sep="\t",
+            header=None,
+            chunksize=chunksize,
+            usecols=[0, 1, 3, 5, 6],
+        ):
+            valid_primers = data_primers[0] == data_primers[3]
+            print(
+                data_primers[valid_primers]
+                .drop(columns=[3, 6])
+                .to_csv(sep="\t", index=False, header=False),
+                file=out,
+            )
+            print(
+                data_primers[~valid_primers].to_csv(
+                    sep="\t", index=False, header=False
+                ),
+                file=log_file,
+            )

--- a/workflow/scripts/build_target_regions.py
+++ b/workflow/scripts/build_target_regions.py
@@ -1,12 +1,20 @@
-log_file=open(snakemake.log[0], 'w')
-out=open(snakemake.output[0], 'w')
+log_file = open(snakemake.log[0], "w")
+out = open(snakemake.output[0], "w")
 
-with open(snakemake.input[0], 'r') as primer_file:
+with open(snakemake.input[0], "r") as primer_file:
     for line in primer_file.readlines():
         line = line.strip().split("\t")
         chr_1 = line[0]
         chr_2 = line[1]
         if chr_1 == chr_2:
-            print("{chr}\t{start}\t{end}".format(chr=chr_1, start=line[1], end=line[5]), file=out)
+            print(
+                "{chr}\t{start}\t{end}".format(chr=chr_1, start=line[1], end=line[5]),
+                file=out,
+            )
         else:
-            print("{primer}\t{chr1}\t{chr2}".format(primer=line[6],chr1=chr_1, chr2=chr_2), file=log_file)
+            print(
+                "{primer}\t{chr1}\t{chr2}".format(
+                    primer=line[6], chr1=chr_1, chr2=chr_2
+                ),
+                file=log_file,
+            )

--- a/workflow/scripts/build_target_regions.py
+++ b/workflow/scripts/build_target_regions.py
@@ -22,3 +22,5 @@ for data_primers in pd.read_csv(
         data_primers[~valid_primers].to_csv(sep="\t", index=False, header=False),
         file=log_file,
     )
+log_file.close()
+out.close()


### PR DESCRIPTION
Currently, the workflow fails in case pairs of primers map to different chromosomes.
To fix this these primers are removed from the final bed file holding the targeted regions.

primers on different chromosomes are written tab-separated into the log holding information about primer name and both chromosomes.