### PR TITLE
Revert "bwa-mem2" migration

### DIFF
--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -1,11 +1,11 @@
 rule map_reads:
     input:
         reads=get_map_reads_input,
-        idx=rules.bwa_mem2_index.output
+        idx=rules.bwa_index.output
     output:
         temp("results/mapped/{sample}.sorted.bam")
     log:
-        "logs/bwa_mem2/{sample}.log"
+        "logs/bwa_mem/{sample}.log"
     params:
         index=lambda w, input: os.path.splitext(input.idx[0])[0],
         extra=get_read_group,
@@ -13,7 +13,7 @@ rule map_reads:
         sort_order="coordinate"
     threads: 8
     wrapper:
-        "0.64.0/bio/bwa-mem2/mem"
+        "0.56.0/bio/bwa/mem"
 
 
 rule mark_duplicates:

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -71,18 +71,18 @@ rule remove_iupac_codes:
         "rbt vcf-fix-iupac-alleles < {input} | bcftools view -Oz > {output}"
 
 
-rule bwa_mem2_index:
+rule bwa_index:
     input:
         "resources/genome.fasta"
     output:
-        multiext("resources/genome.fasta", ".0123", ".amb", ".ann", ".bwt.2bit.64", ".bwt.8bit.32", ".pac")
+        multiext("resources/genome.fasta", ".amb", ".ann", ".bwt", ".pac", ".sa")
     log:
-        "logs/bwa_mem2_index.log"
+        "logs/bwa_index.log"
     resources:
         mem_mb=369000
     cache: True
     wrapper:
-        "0.64.0/bio/bwa-mem2/index"
+        "0.59.2/bio/bwa/index"
 
 
 rule get_vep_cache:


### PR DESCRIPTION
Reverts snakemake-workflows/dna-seq-varlociraptor#44
Reason: on real data bwa-mem2 seems to stop unexpectedly early, without error message.