### PR TITLE
Adjust get_read_group for multi sample config.

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -166,7 +166,7 @@ def get_read_group(wildcards):
     """Denote sample name and platform in read group."""
     return r"-R '@RG\tID:{sample}\tSM:{sample}\tPL:{platform}'".format(
         sample=wildcards.sample,
-        platform=samples.loc[wildcards.sample, "platform"])
+        platform=samples.loc[[wildcards.sample], "platform"].head(1).item())
 
 
 def get_tmb_targets():


### PR DESCRIPTION
I have projects where I have to use the same sample in multiple groups. For example I have a lot of single case samples, but the parents are sequenced chunkwise in pools. In that case I write a config which looks like this:
```
CSDN21	index	CSDN21	ILLUMINA	NA
CSDN47	motherpool	CSDN21	ILLUMINA	NA
CSDN52	fatherpool	CSDN21	ILLUMINA	NA
CSDN22	index	CSDN22	ILLUMINA	NA
CSDN47	motherpool	CSDN22	ILLUMINA	NA
CSDN52	fatherpool	CSDN22	ILLUMINA	NA
CSDN23	index	CSDN23	ILLUMINA	NA
CSDN47	motherpool	CSDN23	ILLUMINA	NA
CSDN52	fatherpool	CSDN23	ILLUMINA	NA
```
This seems to work just fine for the calling, but for the mapping we have to slightly modify the read_group string generation.