### PR TITLE
Bump snakemake min_version to 6.0.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Lint workflow
-      uses: snakemake/snakemake-github-action@v1.16.0
+      uses: snakemake/snakemake-github-action@v1.17.0
       with:
         directory: .
         snakefile: workflow/Snakefile
@@ -28,21 +28,21 @@ jobs:
       uses: textbook/git-checkout-submodule-action@2.0.0
 
     - name: Test workflow (local FASTQs)
-      uses: snakemake/snakemake-github-action@v1.16.0
+      uses: snakemake/snakemake-github-action@v1.17.0
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache --conda-frontend mamba"
 
     - name: Test workflow (local FASTQs, no candidate filtering)
-      uses: snakemake/snakemake-github-action@v1.16.0
+      uses: snakemake/snakemake-github-action@v1.17.0
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-no-candidate-filtering/config.yaml --dryrun --use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache --conda-frontend mamba"
 
     - name: Test workflow (local FASTQs primer)
-      uses: snakemake/snakemake-github-action@v1.16.0
+      uses: snakemake/snakemake-github-action@v1.17.0
       with:
         directory: .test
         snakefile: workflow/Snakefile
@@ -51,14 +51,14 @@ jobs:
           rm -rf .test/resources .test/results
 
     - name: Test report
-      uses: snakemake/snakemake-github-action@v1.16.0
+      uses: snakemake/snakemake-github-action@v1.17.0
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--report report.zip"
 
     - name: Test workflow (SRA FASTQs)
-      uses: snakemake/snakemake-github-action@v1.16.0
+      uses: snakemake/snakemake-github-action@v1.17.0
       with:
         directory: .test
         snakefile: workflow/Snakefile

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,5 +1,5 @@
 from snakemake.utils import min_version
-min_version("5.12.0")
+min_version("6.0.5")
 
 configfile: "config/config.yaml"
 

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -75,7 +75,7 @@ rule sort_calls:
 rule bcftools_concat:
     input:
         calls = get_scattered_calls(),
-        indexes = get_scattered_calls(ext=".bcf.csi"),
+        indexes = get_scattered_calls(ext="bcf.csi"),
     output:
         "results/calls/{group}.{caller}.{scatteritem}.bcf"
     log:

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -77,9 +77,9 @@ rule bcftools_concat:
         calls = get_scattered_calls(),
         indexes = get_scattered_calls(ext=".bcf.csi"),
     output:
-        "results/calls/{group}.{scatteritem}.bcf"
+        "results/calls/{group}.{caller}.{scatteritem}.bcf"
     log:
-        "logs/concat-calls/{group}.{scatteritem}.log"
+        "logs/concat-calls/{group}.{caller}.{scatteritem}.log"
     params:
         "-a -Ob" # TODO Check this
     wrapper:

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -77,9 +77,9 @@ rule bcftools_concat:
         calls = get_scattered_calls(),
         indexes = get_scattered_calls(ext="bcf.csi"),
     output:
-        "results/calls/{group}.{caller}.{scatteritem}.bcf"
+        "results/calls/{group}.{scatteritem}.bcf"
     log:
-        "logs/concat-calls/{group}.{caller}.{scatteritem}.log"
+        "logs/concat-calls/{group}.{scatteritem}.log"
     params:
         "-a -Ob" # TODO Check this
     wrapper:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -201,10 +201,10 @@ def get_tmb_targets():
     else:
         return []
 
-def get_scattered_calls(ext=".bcf"):
+def get_scattered_calls(ext="bcf"):
     def inner(wildcards):
         return expand(
-            "results/calls/{{group}}.{caller}.{{scatteritem}}.sorted{ext}",
+            "results/calls/{{group}}.{caller}.{{scatteritem}}.sorted.{ext}",
             caller=caller,
             ext=ext,
         )
@@ -238,16 +238,16 @@ def get_report_batch(wildcards):
     return groups
 
 
-def get_merge_calls_input(ext=".bcf"):
+def get_merge_calls_input(ext="bcf"):
     def inner(wildcards):
-        return expand("results/calls/{{group}}.{vartype}.{{event}}.{filter}.fdr-controlled{ext}",
+        return expand("results/calls/{{group}}.{vartype}.{{event}}.{filter}.fdr-controlled.{ext}",
                       ext=ext,
                       vartype=["SNV", "INS", "DEL", "MNV", "BND", "INV", "DUP", "REP"],
                       filter=config["calling"]["fdr-control"]["events"][wildcards.event]["filter"])
     return inner
 
-def get_merge_calls_input_report(wildcards, ext=".bcf"):
-    return expand("{{group}}.{vartype}.{{event}}.{filter}=results/calls/{{group}}.{vartype}.{{event}}.{filter}.fdr-controlled{ext}",
+def get_merge_calls_input_report(wildcards, ext="bcf"):
+    return expand("{{group}}.{vartype}.{{event}}.{filter}=results/calls/{{group}}.{vartype}.{{event}}.{filter}.fdr-controlled.{ext}",
                     ext=ext,
                     vartype=["SNV", "INS", "DEL", "MNV", "BND", "INV", "DUP", "REP"],
                     filter=config["calling"]["fdr-control"]["events"][wildcards.event]["filter"])

--- a/workflow/rules/filtering.smk
+++ b/workflow/rules/filtering.smk
@@ -76,8 +76,8 @@ rule control_fdr:
 
 rule merge_calls:
     input:
-        calls=get_merge_calls_input(".bcf"),
-        idx=get_merge_calls_input(".bcf.csi")
+        calls=get_merge_calls_input("bcf"),
+        idx=get_merge_calls_input("bcf.csi")
     output:
         "results/merged-calls/{group}.{event}.fdr-controlled.bcf"
     log:


### PR DESCRIPTION
Since introduction of the scattergather parallelization in this workflow, snakemake was unable to build the DAG due to a stackoverflow occurring because of a repeating wildcard, or more specifically: `{caller}` ended up as part of `{scatteritem}`, leading to the prefix "freebayes." being repeated over and over again. This PR should fix that.
This PR also unifies the use of `{ext}`, which now always has a leading dot in the patterns, i.e. `.{ext}`.
(I also had repeating `.sorted` suffixes, not sure which of these two changes fixed that.)
