### PR TITLE
ensure that in `rule vcf_report` the bcf input file names are only defined once in `input:`

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1,4 +1,5 @@
 import glob
+import path from os
 
 import pandas as pd
 from snakemake.remote import FTP
@@ -172,7 +173,7 @@ def get_batch_bcfs(wildcards, input):
     bcfs = [] 
     for group in get_report_batch(wildcards):
         for file in input.bcfs:
-            if group in file:
+            if path.basename(file).startswith(group):
                 bcfs.append("{group}={file}".format(group=group, file=file))
     return bcfs
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -158,7 +158,6 @@ def get_group_bams_report(group):
             WorkflowError("Primer trimming is only available for paired end data.")
     return [(sample, "results/recal/{}.sorted.bam".format(sample)) for sample in get_group_samples(group)]
 
-
 def get_batch_bams(wildcards, event=False):
     bams = []
     for group in get_report_batch(wildcards):
@@ -168,6 +167,14 @@ def get_batch_bams(wildcards, event=False):
             else:
                 bams.append(bam)
     return bams
+
+def get_batch_bcfs(wildcards, input):
+    bcfs = [] 
+    for group in get_report_batch(wildcards):
+        for file in input.bcfs:
+            if group in file:
+                bcfs.append("{group}={file}".format(group=group, file=file))
+    return bcfs
 
 def get_consensus_input(wildcards):
     if wildcards.read_type == "se":

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1,5 +1,5 @@
 import glob
-import path from os
+from os import path
 
 import pandas as pd
 from snakemake.remote import FTP

--- a/workflow/rules/report.smk
+++ b/workflow/rules/report.smk
@@ -7,7 +7,7 @@ rule vcf_report:
     output:
         report(directory("results/vcf-report/{batch}.{event}/"), htmlindex="index.html", caption="../report/calls.rst", category="Variant calls")
     params:
-        bcfs=lambda w: expand("{group}=results/merged-calls/{group}.{event}.fdr-controlled.bcf", group=get_report_batch(w), event=w.event),
+        bcfs=lambda w, input: get_batch_bcfs(w, input),
         bams=lambda w: get_batch_bams(w, True),
         format_field = "DP AF OBS",
         max_read_depth = config["report"]["max_read_depth"],


### PR DESCRIPTION
With the previous setup, including this rule via the new snakemake `module` syntax  and the `replace_prefix:` keyword will mean that the path specified in `input: bcfs=` gets prefixed, but the path manually provided in the `params: bcfs=` lambda expression does not. Thus the actual files specified on the command-line do not exist.

After the change, the file names from `input: bcfs=` are used directly and matched to the respective `group` with a params function with the arguments `wildcards` and `input`.