### PR TITLE
Bump htslib versions

### DIFF
--- a/workflow/envs/bcftools.yaml
+++ b/workflow/envs/bcftools.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bcftools =1.10
+  - bcftools =1.12

--- a/workflow/envs/bedtools.yaml
+++ b/workflow/envs/bedtools.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
 dependencies:
   - bedtools =2.29
-  - samtools =1.10
+  - samtools =1.12

--- a/workflow/envs/htslib.yaml
+++ b/workflow/envs/htslib.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - htslib =1.10
+  - htslib =1.12

--- a/workflow/envs/rbt.yaml
+++ b/workflow/envs/rbt.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - rust-bio-tools =0.21
-  - bcftools =1.10
+  - bcftools =1.12

--- a/workflow/envs/samtools.yaml
+++ b/workflow/envs/samtools.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - samtools =1.10
+  - samtools =1.12

--- a/workflow/envs/snpsift.yaml
+++ b/workflow/envs/snpsift.yaml
@@ -3,4 +3,4 @@ channels:
   - bioconda
 dependencies:
   - snpsift =4.3.1
-  - bcftools =1.10
+  - bcftools =1.12


### PR DESCRIPTION
bump versions of htslib dependent tools to 1.12, i.e. samtools, bcftools, htslib itself