### PR TITLE
fix delly calls by removing breakends for now since they cause invalid…

### DIFF
--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -39,9 +39,23 @@ rule delly:
         "0.68.0/bio/delly"
 
 
+# Delly breakends lead to invalid BCFs after VEP annotation (invalid RLEN). Therefore we exclude them for now.
+rule fix_delly_calls:
+    input:
+        "results/candidate-calls/{group}.delly.bcf",
+    output:
+        "results/candidate-calls/{group}.delly.no_bnds.bcf",
+    log:
+        "logs/fix_delly_calls/{group}.log",
+    conda:
+        "../envs/bcftools.yaml"
+    shell:
+        """bcftools view -e 'INFO/SVTYPE="BND"' {input} -Ob > {output} 2> {log}"""
+
+
 rule scatter_candidates:
     input:
-        "results/candidate-calls/{group}.{caller}.bcf",
+        get_fixed_candidate_calls,
     output:
         scatter.calling(
             "results/candidate-calls/{{group}}.{{caller}}.{scatteritem}.bcf"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -437,6 +437,13 @@ def get_fdr_control_params(wildcards):
     return {"threshold": threshold, "events": events, "local": local}
 
 
+def get_fixed_candidate_calls(wildcards):
+    if wildcards.caller == "delly":
+        return "results/candidate-calls/{group}.delly.no_bnds.bcf"
+    else:
+        return "results/candidate-calls/{group}.{caller}.bcf"
+
+
 wildcard_constraints:
     group="|".join(samples["group"].unique()),
     sample="|".join(samples["sample_name"]),


### PR DESCRIPTION
… BCFs after annotation.

[W::bcf_record_check] BCF record at 19:20064191 has invalid RLEN (-8103858). Only one invalid RLEN will be reported.