### PR TITLE
default to autodetect primer library size (and error) with yara + value docs

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,9 +19,11 @@ primers:
     # path to fasta files containg primer sequences
     primers_fa1: "path/to/primer-fa1"
     primers_fa2: "path/to/primer-fa2"
-     # Library mean + error determines the maximum insert size between the outer primer ends.
+    # Library mean + error determines the maximum insert size between the outer primer ends.
+    # Specify 0 to have yara autodetect the primer library insert size error.
     library_error: 0
     # Mean insert size between the outer primer ends.
+    # Specify 0 to have yara autodetect the primer library insert size.
     library_length: 0
 
 # Estimation of tumor mutational burden.

--- a/workflow/rules/primers.smk
+++ b/workflow/rules/primers.smk
@@ -51,15 +51,23 @@ rule map_primers:
     output:
         "results/primers/primers.bam",
     params:
-        library_error=config["primers"]["trimming"]["library_error"],
-        library_len=config["primers"]["trimming"]["library_length"],
+        library_len=(
+            "-ll {}".format(config["primers"]["trimming"]["library_length"])
+            if config["primers"]["trimming"]["library_length"] > 0
+            else ""
+        ),
+        library_error=(
+            "-ld {}".format(config["primers"]["trimming"]["library_error"])
+            if config["primers"]["trimming"]["library_error"] > 0
+            else ""
+        ),
         ref_prefix=lambda w, input: os.path.splitext(input.ref)[0],
     log:
         "logs/yara/map_primers.log",
     conda:
         "../envs/yara.yaml"
     shell:
-        "yara_mapper -t {threads} -ll {params.library_len} -ld {params.library_error} -o {output} {params.ref_prefix} {input.reads} > {log}"
+        "yara_mapper -t {threads} {params.library_len} {params.library_error} -o {output} {params.ref_prefix} {input.reads} > {log}"
 
 
 rule filter_unmapped_primers:

--- a/workflow/schemas/samples.schema.yaml
+++ b/workflow/schemas/samples.schema.yaml
@@ -4,19 +4,27 @@ description: an entry in the sample sheet
 properties:
   sample_name:
     type: string
-    pattern: "^[a-zA-Z_\-0-9]+$"
     description: sample name/identifier (alphanumeric string, that may additionally contain '_' and '-')
+    pattern: "^[a-zA-Z_0-9-]+$"
   alias:
     type: string
-    pattern: "^[a-zA-Z_\-0-9]+$"
     description: sample name within the VCF/BCF files generated for a group (e.g. tumor, normal, etc.) (alphanumeric string, that may additionally contain '_' and '-')
+    pattern: "^[a-zA-Z_0-9-]+$"
   group:
     type: string
-    pattern: "^[a-zA-Z_\-0-9]+$"
     description: group of samples called jointly (alphanumeric string, that may additionally contain '_' and '-')
+    pattern: "^[a-zA-Z_0-9-]+$"
   platform:
     type: string
-    enum: ["CAPILLARY", "LS454", "ILLUMINA", "SOLID", "HELICOS", "IONTORRENT", "ONT", "PACBIO"]
+    enum:
+      - "CAPILLARY"
+      - "LS454"
+      - "ILLUMINA"
+      - "SOLID"
+      - "HELICOS"
+      - "IONTORRENT"
+      - "ONT"
+      - "PACBIO"
     description: used sequencing platform
   purity:
     type: number
@@ -24,7 +32,6 @@ properties:
     maximum: 1.0
     description: Purity to use for tumor/normal groups.
 
-  
 
 required:
   - sample_name

--- a/workflow/schemas/units.schema.yaml
+++ b/workflow/schemas/units.schema.yaml
@@ -4,11 +4,11 @@ type: object
 properties:
   sample_name:
     type: string
-    pattern: "^[a-zA-Z_\-0-9]+$"
+    pattern: "^[a-zA-Z_0-9-]+$"
     description: sample name/id the unit has been sequenced from (alphanumeric string, that may additionally contain '_' and '-')
   unit_name:
     type: string
-    pattern: "^[a-zA-Z_\-0-9]+$"
+    pattern: "^[a-zA-Z_0-9-]+$"
     description: unit id (alphanumeric string, that may additionally contain '_' and '-')
   fq1:
     type: string


### PR DESCRIPTION
Set the primer trimming default configuration mode to autodetect primer library size (and error) with yara. Document that this is done by setting the `config.yaml` values to 0.