### PR TITLE
Merge closeby regions

### DIFF
--- a/workflow/rules/regions.smk
+++ b/workflow/rules/regions.smk
@@ -27,7 +27,7 @@ rule merge_group_regions:
     conda:
         "../envs/bedtools.yaml"
     shell:
-        "zcat {input} | sort -k1,1 -k2,2n - | mergeBed -i - > {output} 2> {log}"
+        "zcat {input} | sort -k1,1 -k2,2n - | mergeBed -i - -d 15000 > {output} 2> {log}"
 
 
 rule filter_group_regions:


### PR DESCRIPTION
The recently added featur to only call regions with coverage leads to lots of freebayes invokes with short regions. This fix merges regions that are close to each other (< 15kb) and drastically reduces the runtime of freebayes by a factor of 40.