### PR TITLE
feat: normalize candidate calls in case of multiple samples

### DIFF
--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -64,8 +64,8 @@ rule annotate_dgidb:
     params:
         datasources=(
             "-s {}".format(" ".join(config["annotations"]["dgidb"]["datasources"]))
-            if config["annotations"]["dgidb"].get("datasources", "")
-            else ""
+        if config["annotations"]["dgidb"].get("datasources", "")
+        else ""
         ),
     output:
         "results/calls/{prefix}.dgidb.bcf",

--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -13,10 +13,8 @@ rule freebayes:
     params:
         # genotyping is performed by varlociraptor, hence we deactivate it in freebayes by 
         # always setting --pooled-continuous
-        extra="--pooled-continuous --min-alternate-count {} --min-alternate-fraction {}".format(
-            1 if is_activated("calc_consensus_reads") else 2,
-            config["params"]["freebayes"].get("min_alternate_fraction", "0.05"),
-        ),
+        extra=get_freebayes_params,
+        normalize=get_freebayes_normalize,
     threads: workflow.cores - 1  # use all available cores -1 (because of the pipe) for calling
     wrapper:
         "0.80.0/bio/freebayes"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -642,3 +642,30 @@ def get_vembrane_expression(wc):
 
 def get_sample_alias(wildcards):
     return samples.loc[wildcards.sample, "alias"]
+
+
+def get_freebayes_params(wildcards):
+    return "--pooled-continuous --min-alternate-count {} --min-alternate-fraction {}".format(
+        1 if is_activated("calc_consensus_reads") else 2,
+        config["params"]["freebayes"].get("min_alternate_fraction", "0.05"),
+    )
+
+
+def get_freebayes_normalize(wildcards, input):
+    group = get_group_samples(wildcards.group)
+    # METHOD: Normalize whenever we call more than one sample per group
+    # The reason is that in complex scenarios, we want primitive alleles
+    # in order to be able to correctly identify events.
+    #
+    # Example:
+    # The child has
+    # CGAGCGGA -> TGGCTGGA
+    # while both parent have
+    # CGAGCGGA -> TGGCTGGG
+    #
+    # The correct genomic interpretation is that the G allele in the end is lost in the child.
+    # But in above MNV representation, it looks like a denovo event overall, while the
+    # two SNVs at the beginning are actually inherited.
+    if len(group) != 1:
+        return "-a --rm-dup exact -f {input.ref}".format(input=input)
+    return False

--- a/workflow/rules/primers.smk
+++ b/workflow/rules/primers.smk
@@ -81,8 +81,8 @@ rule bowtie_map:
         prefix="resources/bowtie_build/genome.fasta",
         insertsize=(
             "-X {}".format(config["primers"]["trimming"].get("library_length"))
-            if config["primers"]["trimming"].get("library_length", 0) != 0
-            else ""
+        if config["primers"]["trimming"].get("library_length", 0) != 0
+        else ""
         ),
     log:
         "logs/bowtie/{panel}_map.log",


### PR DESCRIPTION
Normalize whenever we call more than one sample per group
The reason is that in complex scenarios, we want primitive alleles
in order to be able to correctly identify events.

Example:
The child has
CGAGCGGA -> TGGCTGGA
while both parent have
CGAGCGGA -> TGGCTGGG

The correct genomic interpretation is that the G allele in the end is lost in the child.
But in above MNV representation, it looks like a denovo event overall, while the two SNVs at the beginning are actually inherited.

cc @christopher-schroeder