### PR TITLE
Update vcf-report

### DIFF
--- a/workflow/resources/custom-table-report.js
+++ b/workflow/resources/custom-table-report.js
@@ -209,9 +209,10 @@ $(document).ready(function () {
             vegaEmbed('#Prob', probSpec);
         }
 
-        var regex = /([0-9]+)(N|B|P|S|V|n|b|p|s|v)(s|p)(\+|\-|\*)(\>|\<|\*|\!)/g;
+        var regex = /([0-9]+)(N|E|B|P|S|V|n|e|b|p|s|v)(s|p)(\#|\*|\.)(\+|\-|\*)(\>|\<|\*|\!)(\^|\*)(\$|\.)(\*|\.)/g;
         var effects = {
             "N": "None",
+            "E": "Equal",
             "B": "Barely",
             "P": "Positive",
             "S": "Strong",
@@ -226,7 +227,7 @@ $(document).ready(function () {
         }
         $.each($(this).data("format")["OBS"], function(sample_name, observation) {
             while ((result = regex.exec(observation)) != null) {
-                strand = result[4].replace("*", "±")
+                strand = result[5].replace("*", "±")
                 effect = effects[result[2].toUpperCase()]
                 var quality = "Low mapping quality";
                 if (result[2] == result[2].toUpperCase()) {
@@ -235,11 +236,11 @@ $(document).ready(function () {
                 observations.push({
                     "sample": sample_name,
                     "strand": strand,
-                    "strand_orientation": strand + ' ' + orientation[result[5]],
+                    "strand_orientation": strand + ' ' + orientation[result[6]],
                     "effect": effect,
                     "times": parseFloat(result[1]),
                     "quality": quality,
-                    "orientation": orientation[result[5]]
+                    "orientation": orientation[result[6]]
                 })
             }
         })
@@ -307,9 +308,20 @@ $(document).ready(function () {
         }
 
         var binom_dist = []
-        af = $(this).data("format")["DP"]
-        $.each($(this).data("format")["AF"], function(sample_name, allele_frequency) {
-            binom_dist = binom_dist.concat(calcBinomDist(parseFloat(allele_frequency), af[sample_name][0], sample_name));
+        $.each($(this).data("format")["AFD"], function(sample_name, afd_string) {
+            if (afd_string !== undefined) {
+                var allele_frequency_distribution = afd_string.split(',')
+                for (let dist_idx in allele_frequency_distribution) {
+                    var values = allele_frequency_distribution[dist_idx].split('=')
+                    var frequency = values[0]
+                    var posterior_density = Math.pow(10, (-values[1]/10))
+                    binom_dist.push({
+                        "frequency": frequency,
+                        "binomProb": posterior_density,
+                        "sample": sample_name
+                    });
+                }
+            }
         })
         if (binom_dist.length > 0) {
             $('#custom-sidebar').append('<div id="AlleleFreq">');
@@ -319,10 +331,7 @@ $(document).ready(function () {
                 "data": {
                     values: binom_dist
                 },
-                "mark": {
-                    "type": "line",
-                    "interpolate": "linear"
-                },
+                "mark": "point",
                 "encoding": {
                     "column": {
                         "field": "sample",
@@ -337,7 +346,8 @@ $(document).ready(function () {
                     "y": {
                         "field": "binomProb",
                         "type": "quantitative",
-                        "title": "Density"
+                        "title": "Density",
+                        "scale": {"type": "log"}
                     },
                     "tooltip": [{
                         "field": "binomProb",
@@ -363,22 +373,6 @@ $(document).ready(function () {
             $('#custom-sidebar').append('<div id="PolyPhenScores">');
             $('#custom-sidebar').append('</div>');
             plotScores("PolyPhen", polyphen_scores, "PolyPhenScores")
-        }
-
-        function calcBinomDist(alleleFreq, coverage, sample_name) {
-            var binomValues = [];
-            var frequency = 0.01;
-            var k = Math.round(alleleFreq * coverage);
-            while (frequency < 1) {
-                var prob_binom = Math.exp(((coverage+0.5)*Math.log(coverage)-(k+0.5)*Math.log(k)-(coverage-k+0.5)*Math.log(coverage-k)-0.5*Math.log(2*Math.PI)) + (Math.log(frequency)*k) + (Math.log(1 - frequency)*(coverage - k)))
-                binomValues.push({
-                    "frequency": frequency,
-                    "binomProb": prob_binom,
-                    "sample": sample_name
-                });
-                frequency += 0.01;
-            }
-            return binomValues;
         }
 
 

--- a/workflow/rules/report.smk
+++ b/workflow/rules/report.smk
@@ -14,7 +14,7 @@ rule vcf_report:
     params:
         bcfs=get_report_bcf_params,
         bams=get_report_bam_params,
-        format_field="DP AF OBS",
+        format_field="DP AF SOBS OBS AFD",
         max_read_depth=config["report"]["max_read_depth"],
         js_files="{math} {template}".format(
             math=get_resource("math.min.js"),


### PR DESCRIPTION
Due to some breaking changes in the latest varlociraptor versions an update of the `custom-report-template` was necessary.

Fixes include:

- values of af density plot are now directly drawn from the `AFD` format-field and do not need to be calculated any more.
- observation plot is functional again. Some changes were required as the observation-field gained additional information
- short observations (SOBS) have been added 