### PR TITLE
Fix parameter for mark_duplicates

### DIFF
--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -43,7 +43,7 @@ rule mark_duplicates:
     params:
         extra=lambda wc: "{c} {b} {d}".format(
             c=config["params"]["picard"]["MarkDuplicates"],
-            b="" if units.loc[wc.sample]["umis"].isnull() else "BARCODE_TAG=RX",
+            b="" if units.loc[wc.sample]["umis"].isnull().any() else "BARCODE_TAG=RX",
             d="TAG_DUPLICATE_SET_MEMBERS=true"
             if is_activated("calc_consensus_reads")
             else "",


### PR DESCRIPTION
When calculating duplicate reads it turns out that building the `extra`-param for marking duplicates fails due to a mistake when validating the truth value of a Pandas Series.
This has been fixed.