### PR TITLE
Fix vcf-report

### DIFF
--- a/workflow/resources/custom-table-report.js
+++ b/workflow/resources/custom-table-report.js
@@ -16,13 +16,13 @@ $(document).ready(function () {
         var polyphen_scores = []
         for (let j = 1; j <= ann_length; j++) {
             var transcript = $(that).data('ann[' + j + '][7]')
-            sift_score = $(that).data('ann[' + j + '][36]')
+            sift_score = $(that).data('ann[' + j + '][37]')
             if (sift_score != "" && sift_score !== undefined) {
                 sift_score = sift_score.split("(")[1].slice(0, -1)
                 sift_scores = parse_score(sift_scores, sift_score, "SIFT", transcript)
             }
 
-            polyphen_score = $(that).data('ann[' + j + '][37]')
+            polyphen_score = $(that).data('ann[' + j + '][38]')
             if (polyphen_score != "" && polyphen_score !== undefined) {
                 polyphen_score = polyphen_score.split("(")[1].slice(0, -1)
                 polyphen_scores = parse_score(polyphen_scores, polyphen_score, "PolyPhen", transcript)


### PR DESCRIPTION
It looks like the annotation field created by VEP has received a new value.
Therefore plots are failing as the index needs to be adjusted.

To prevent wrong indexing in the future it would probably help if `rbt vcf-report` saves the values of the ANN-field in a dictionary for directly accessing the correct values by name.