### PR TITLE
fix parameter for bowtie

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -288,7 +288,7 @@ def get_sample_primer_fastas(sample):
         return config["primers"]["trimming"]["primers_fa1"]
 
 
-def get_panel_primer_fastas(panel):
+def get_panel_primer_input(panel):
     if panel == "uniform":
         if config["primers"]["trimming"].get("primers_fa2", ""):
             return [
@@ -301,6 +301,12 @@ def get_panel_primer_fastas(panel):
         if not pd.isna(panel["fa2"]):
             return [panel["fa1"], panel["fa2"]]
         return panel["fa1"]
+
+
+def input_is_fasta(primers):
+    primers = primers[0] if isinstance(primers, list) else primers
+    fasta_suffixes = ("fasta", "fa")
+    return True if primers.endswith(fasta_suffixes) else False
 
 
 def get_primer_regions(wc):

--- a/workflow/rules/primers.smk
+++ b/workflow/rules/primers.smk
@@ -81,8 +81,8 @@ rule bowtie_map:
         prefix="resources/bowtie_build/genome.fasta",
         insertsize=(
             "-X {}".format(config["primers"]["trimming"].get("library_length"))
-        if config["primers"]["trimming"].get("library_length", 0) != 0
-        else ""
+            if config["primers"]["trimming"].get("library_length", 0) != 0
+            else ""
         ),
         read_format=lambda wc, input: "-f" if input_is_fasta(input.primers) else "",
     log:

--- a/workflow/rules/primers.smk
+++ b/workflow/rules/primers.smk
@@ -84,13 +84,13 @@ rule bowtie_map:
             if config["primers"]["trimming"].get("library_length", 0) != 0
             else ""
         ),
-        read_format=lambda wc, input: "-f" if input_is_fasta(input.primers) else "",
+        primer_format=lambda wc, input: "-f" if input_is_fasta(input.primers) else "",
     log:
         "logs/bowtie/{panel}_map.log",
     conda:
         "../envs/bowtie.yaml"
     shell:
-        "bowtie {params.primers} -x {params.prefix} {params.insertsize} {params.read_format} -S | samtools view -b - > {output} 2> {log}"
+        "bowtie {params.primers} -x {params.prefix} {params.insertsize} {params.primer_format} -S | samtools view -b - > {output} 2> {log}"
 
 
 rule filter_unmapped_primers:
@@ -101,7 +101,7 @@ rule filter_unmapped_primers:
     params:
         extra=(
             lambda wc: "-b -f 2"
-            if isinstance(get_panel_primer_fastas(wc.panel), list)
+            if isinstance(get_panel_primer_input(wc.panel), list)
             else "-b -F 4"
         ),
     log:

--- a/workflow/rules/primers.smk
+++ b/workflow/rules/primers.smk
@@ -90,7 +90,7 @@ rule bowtie_map:
     conda:
         "../envs/bowtie.yaml"
     shell:
-        "bowtie {params.primers} -x {params.prefix} {params.insertsize} -f -S | samtools view -b - > {output} 2> {log}"
+        "bowtie {params.primers} -x {params.prefix} {params.insertsize} {params.read_format} -S | samtools view -b - > {output} 2> {log}"
 
 
 rule filter_unmapped_primers:

--- a/workflow/rules/primers.smk
+++ b/workflow/rules/primers.smk
@@ -76,7 +76,7 @@ rule bowtie_map:
                 r1=input.reads[0], r2=input.reads[1]
             )
             if isinstance(input.reads, list)
-            else "-f {}".format(input.reads)
+            else input.reads
         ),
         prefix="resources/bowtie_build/genome.fasta",
         insertsize=(
@@ -89,7 +89,7 @@ rule bowtie_map:
     conda:
         "../envs/bowtie.yaml"
     shell:
-        "bowtie {params.reads} -x {params.prefix} {params.insertsize} -S | samtools view -b - > {output} 2> {log}"
+        "bowtie {params.reads} -x {params.prefix} {params.insertsize} -f -S | samtools view -b - > {output} 2> {log}"
 
 
 rule filter_unmapped_primers:


### PR DESCRIPTION
When mapping primers bowtie currently expects fastq-files as input.
In its current implementation the `-f` flag for accepting fasta files is only set for single primers.
This has been fixed.

Edit: As we have a testcase using fastq-primers both types are allowed now.