### PR TITLE
actually load htslib for process_revel_scores (to have bgzip available)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         directory: .
         snakefile: workflow/Snakefile
-        stagein: "mamba install -y fastparquet; conda list;"
+        stagein: "mamba install -y --channel conda-forge fastparquet=0.8.0; conda list;"
         args: "--lint"
 
   Testing:
@@ -45,7 +45,7 @@ jobs:
       with:
         directory: .test
         snakefile: workflow/Snakefile
-        stagein: "mamba install -y fastparquet; conda list;"
+        stagein: "mamba install -y --channel conda-forge fastparquet=0.8.0; conda list;"
         args: "--use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache --conda-frontend mamba"
 
     - name: Test workflow (local FASTQs, target regions)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         directory: .
         snakefile: workflow/Snakefile
-        stagein: "mamba install -y -n snakemake --channel conda-forge fastparquet=0.8.0"
+        stagein: "mamba install -y -n snakemake --channel conda-forge pyarrow=6.0"
         args: "--lint"
 
   Testing:
@@ -45,7 +45,7 @@ jobs:
       with:
         directory: .test
         snakefile: workflow/Snakefile
-        stagein: "mamba install -y -n snakemake --channel conda-forge fastparquet=0.8.0"
+        stagein: "mamba install -y -n snakemake --channel conda-forge  pyarrow=6.0"
         args: "--use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache --conda-frontend mamba"
 
     - name: Test workflow (local FASTQs, target regions)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
   Testing:
     runs-on: ubuntu-latest
     needs: 
-      - Linting
+#      - Linting
       - Formatting
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Lint workflow
-      uses: snakemake/snakemake-github-action@v1.22.0
+      uses: snakemake/snakemake-github-action@v1.24.0
       with:
         directory: .
         snakefile: workflow/Snakefile
@@ -40,35 +40,35 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Test workflow (local FASTQs)
-      uses: snakemake/snakemake-github-action@v1.22.0
+      uses: snakemake/snakemake-github-action@v1.24.0
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache --conda-frontend mamba"
 
     - name: Test workflow (local FASTQs, target regions)
-      uses: snakemake/snakemake-github-action@v1.22.0
+      uses: snakemake/snakemake-github-action@v1.24.0
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-target-regions/config.yaml --use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache --conda-frontend mamba"
 
     - name: Test report
-      uses: snakemake/snakemake-github-action@v1.22.0
+      uses: snakemake/snakemake-github-action@v1.24.0
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--report report.zip"
 
     - name: Test workflow (local FASTQs, no candidate filtering)
-      uses: snakemake/snakemake-github-action@v1.22.0
+      uses: snakemake/snakemake-github-action@v1.24.0
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-no-candidate-filtering/config.yaml --dryrun --use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache --conda-frontend mamba"
 
     - name: Test workflow (local FASTQs primer)
-      uses: snakemake/snakemake-github-action@v1.22.0
+      uses: snakemake/snakemake-github-action@v1.24.0
       with:
         directory: .test
         snakefile: workflow/Snakefile
@@ -77,7 +77,7 @@ jobs:
           rm -rf .test/resources .test/results
 
     - name: Test workflow (SRA FASTQs)
-      uses: snakemake/snakemake-github-action@v1.22.0
+      uses: snakemake/snakemake-github-action@v1.24.0
       with:
         directory: .test
         snakefile: workflow/Snakefile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         directory: .
         snakefile: workflow/Snakefile
-        stagein: "mamba install -y --channel conda-forge fastparquet=0.8.0; conda list;"
+        stagein: "mamba install -y -n snakemake --channel conda-forge fastparquet=0.8.0"
         args: "--lint"
 
   Testing:
@@ -45,7 +45,7 @@ jobs:
       with:
         directory: .test
         snakefile: workflow/Snakefile
-        stagein: "mamba install -y --channel conda-forge fastparquet=0.8.0; conda list;"
+        stagein: "mamba install -y -n snakemake --channel conda-forge fastparquet=0.8.0"
         args: "--use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache --conda-frontend mamba"
 
     - name: Test workflow (local FASTQs, target regions)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         directory: .
         snakefile: workflow/Snakefile
-        stagein: "mamba install fastparquet"
+        stagein: "mamba install -y fastparquet; conda list;"
         args: "--lint"
 
   Testing:
@@ -45,7 +45,7 @@ jobs:
       with:
         directory: .test
         snakefile: workflow/Snakefile
-        stagein: "mamba install fastparquet"
+        stagein: "mamba install -y fastparquet; conda list;"
         args: "--use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache --conda-frontend mamba"
 
     - name: Test workflow (local FASTQs, target regions)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,17 +20,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_SNAKEMAKE_SNAKEFMT: true
 
-  Linting:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Lint workflow
-      uses: snakemake/snakemake-github-action@v1.24.0
-      with:
-        directory: .
-        snakefile: workflow/Snakefile
-        stagein: "mamba install -y --channel conda-forge fastparquet=0.8.0; conda list;"
-        args: "--lint"
+#  Linting:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@v2
+#    - name: Lint workflow
+#      uses: snakemake/snakemake-github-action@v1.24.0
+#      with:
+#        directory: .
+#        snakefile: workflow/Snakefile
+#        stagein: "mamba install -y --channel conda-forge fastparquet=0.8.0; conda list;"
+#        args: "--lint"
 
   Testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
       with:
         directory: .
         snakefile: workflow/Snakefile
+        stagein: "mamba install fastparquet"
         args: "--lint"
 
   Testing:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,22 +20,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_SNAKEMAKE_SNAKEFMT: true
 
-#  Linting:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: Lint workflow
-#      uses: snakemake/snakemake-github-action@v1.24.0
-#      with:
-#        directory: .
-#        snakefile: workflow/Snakefile
-#        stagein: "mamba install -y --channel conda-forge fastparquet=0.8.0; conda list;"
-#        args: "--lint"
+  Linting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Lint workflow
+      uses: snakemake/snakemake-github-action@v1.24.0
+      with:
+        directory: .
+        snakefile: workflow/Snakefile
+        stagein: "mamba install -y --channel conda-forge fastparquet=0.8.0; conda list;"
+        args: "--lint"
 
   Testing:
     runs-on: ubuntu-latest
     needs: 
-#      - Linting
+      - Linting
       - Formatting
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,7 @@ jobs:
       with:
         directory: .test
         snakefile: workflow/Snakefile
+        stagein: "mamba install fastparquet"
         args: "--use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache --conda-frontend mamba"
 
     - name: Test workflow (local FASTQs, target regions)

--- a/workflow/envs/render_scenario.yaml
+++ b/workflow/envs/render_scenario.yaml
@@ -1,6 +1,0 @@
-channels:
-  - conda-forge
-dependencies:
-  - jinja2 =2.10
-  - pandas =1.3
-  - fastparquet =0.8.0

--- a/workflow/envs/render_scenario.yaml
+++ b/workflow/envs/render_scenario.yaml
@@ -3,3 +3,4 @@ channels:
 dependencies:
   - jinja2 =2.10
   - pandas =1.3
+  - fastparquet =0.8.0

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -1,3 +1,6 @@
+import fastparquet
+
+
 rule render_scenario:
     input:
         local(config["calling"]["scenario"]),

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -18,8 +18,7 @@ rule render_scenario:
         "logs/render-scenario/{group}.log",
     params:
         samples=samples_parquet_bytes,
-    conda:
-        "../envs/render_scenario.yaml"
+    conda: none
     script:
         "../scripts/render-scenario.py"
 

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -10,7 +10,7 @@ rule render_scenario:
     log:
         "logs/render-scenario/{group}.log",
     params:
-        samples=samples,
+        samples=samples.to_parquet(),
     conda:
         "../envs/render_scenario.yaml"
     script:

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -17,8 +17,9 @@ rule render_scenario:
     log:
         "logs/render-scenario/{group}.log",
     params:
-        samples=samples_parquet_bytes,
-    conda: None
+        samples=samples,
+    conda:
+        None
     script:
         "../scripts/render-scenario.py"
 

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -1,5 +1,6 @@
 import fastparquet
 
+
 rule render_scenario:
     input:
         local(config["calling"]["scenario"]),

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -1,6 +1,3 @@
-import fastparquet
-
-
 rule render_scenario:
     input:
         local(config["calling"]["scenario"]),
@@ -13,7 +10,7 @@ rule render_scenario:
     log:
         "logs/render-scenario/{group}.log",
     params:
-        samples=samples.to_parquet(),
+        samples=samples.to_parquet(engine="fastparquet"),
     conda:
         "../envs/render_scenario.yaml"
     script:

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -18,7 +18,7 @@ rule render_scenario:
         "logs/render-scenario/{group}.log",
     params:
         samples=samples_parquet_bytes,
-    conda: none
+    conda: None
     script:
         "../scripts/render-scenario.py"
 

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -1,10 +1,6 @@
 import io
 
 
-samples_parquet_bytes = io.BytesIO()
-samples.to_parquet(samples_parquet_bytes, engine="pyarrow")
-
-
 rule render_scenario:
     input:
         local(config["calling"]["scenario"]),

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -1,6 +1,3 @@
-import fastparquet
-
-
 rule render_scenario:
     input:
         local(config["calling"]["scenario"]),

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -10,7 +10,7 @@ rule render_scenario:
     log:
         "logs/render-scenario/{group}.log",
     params:
-        samples=samples.to_parquet(engine="fastparquet"),
+        samples=samples.to_parquet(index=False, engine="fastparquet"),
     conda:
         "../envs/render_scenario.yaml"
     script:

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -4,6 +4,7 @@ import io
 samples_parquet_bytes = io.BytesIO()
 samples.to_parquet(samples_parquet_bytes, engine="pyarrow")
 
+
 rule render_scenario:
     input:
         local(config["calling"]["scenario"]),

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -1,3 +1,9 @@
+import io
+
+
+samples_parquet_bytes = io.BytesIO()
+samples.to_parquet(samples_parquet_bytes, engine="pyarrow")
+
 rule render_scenario:
     input:
         local(config["calling"]["scenario"]),
@@ -10,7 +16,7 @@ rule render_scenario:
     log:
         "logs/render-scenario/{group}.log",
     params:
-        samples=samples.to_parquet(index=False, engine="fastparquet"),
+        samples=samples_parquet_bytes,
     conda:
         "../envs/render_scenario.yaml"
     script:

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -1,3 +1,5 @@
+import fastparquet
+
 rule render_scenario:
     input:
         local(config["calling"]["scenario"]),

--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -37,7 +37,7 @@ rule delly:
         extra=config["params"].get("delly", ""),
     threads: lambda _, input: len(input.samples)  # delly parallelizes over the number of samples
     wrapper:
-        "0.80.0/bio/delly"
+        "v1.1.0/bio/delly"
 
 
 # Delly breakends lead to invalid BCFs after VEP annotation (invalid RLEN). Therefore we exclude them for now.

--- a/workflow/rules/plugins.smk
+++ b/workflow/rules/plugins.smk
@@ -17,9 +17,9 @@ rule process_revel_scores:
     shell:
         """
         tmpfile=$(mktemp {resources.tmpdir}/revel_scores.XXXXXX)
-        unzip -p {input} | tr "," "\t" | sed '1s/.*/#&/' | bgzip -c > $tmpfile
+        unzip -p {input} | tr "," "\t" | sed '1s/.*/#&/' | gzip -c > $tmpfile
         if [ "{wildcards.ref}" == "GRCh38" ] ; then
-            zgrep -h -v ^#chr $tmpfile | awk '$3 != "." ' | sort -k1,1 -k3,3n - | cat <(zcat $tmpfile | head -n1) - | bgzip -c > {output}
+            zgrep -h -v ^#chr $tmpfile | awk '$3 != "." ' | sort -k1,1 -k3,3n - | cat <(zcat $tmpfile | head -n1) - | gzip -c > {output}
         elif [ "{wildcards.ref}" == "GRCh37" ] ; then
             cat $tmpfile > {output}
         else

--- a/workflow/rules/plugins.smk
+++ b/workflow/rules/plugins.smk
@@ -14,6 +14,8 @@ rule process_revel_scores:
         "resources/{ref}_revel_scores.tsv.gz",
     log:
         "logs/vep_plugins/process_{ref}_revel_scores.log",
+    conda:
+        "../envs/htslib.yaml"
     shell:
         """
         tmpfile=$(mktemp {resources.tmpdir}/revel_scores.XXXXXX)

--- a/workflow/rules/plugins.smk
+++ b/workflow/rules/plugins.smk
@@ -17,9 +17,9 @@ rule process_revel_scores:
     shell:
         """
         tmpfile=$(mktemp {resources.tmpdir}/revel_scores.XXXXXX)
-        unzip -p {input} | tr "," "\t" | sed '1s/.*/#&/' | gzip -c > $tmpfile
+        unzip -p {input} | tr "," "\t" | sed '1s/.*/#&/' | bgzip -c > $tmpfile
         if [ "{wildcards.ref}" == "GRCh38" ] ; then
-            zgrep -h -v ^#chr $tmpfile | awk '$3 != "." ' | sort -k1,1 -k3,3n - | cat <(zcat $tmpfile | head -n1) - | gzip -c > {output}
+            zgrep -h -v ^#chr $tmpfile | awk '$3 != "." ' | sort -k1,1 -k3,3n - | cat <(zcat $tmpfile | head -n1) - | bgzip -c > {output}
         elif [ "{wildcards.ref}" == "GRCh37" ] ; then
             cat $tmpfile > {output}
         else

--- a/workflow/scripts/render-scenario.py
+++ b/workflow/scripts/render-scenario.py
@@ -1,13 +1,12 @@
 import sys
 from jinja2 import Template
 import pandas as pd
-import fastparquet
 
 sys.stderr = open(snakemake.log[0], "w")
 
 
 with open(snakemake.input[0]) as template, open(snakemake.output[0], "w") as out:
-    samples = pd.read_parquet(snakemake.params.samples)
+    samples = snakemake.params.samples
     out.write(
         Template(template.read()).render(
             samples=samples[samples["group"] == snakemake.wildcards.group]

--- a/workflow/scripts/render-scenario.py
+++ b/workflow/scripts/render-scenario.py
@@ -1,12 +1,13 @@
 import sys
 from jinja2 import Template
 import pandas as pd
+import fastparquet
 
 sys.stderr = open(snakemake.log[0], "w")
 
 
 with open(snakemake.input[0]) as template, open(snakemake.output[0], "w") as out:
-    samples = snakemake.params.samples
+    samples = pd.read_parquet(snakemake.params.samples)
     out.write(
         Template(template.read()).render(
             samples=samples[samples["group"] == snakemake.wildcards.group]


### PR DESCRIPTION
Original plan:
Use `gzip` instead of `bgzip` in `rule process_revel_scores:`, as `gzip` is commonly available in Linux, whereas `bgzip` is only available in the `htslib`. The alternative would be to add a conda environment to this rule, that installs `htslib`, but as all other commands are plain Linux tools, I would opt for the change proposed here. Also, I double-checked that the flag `-c` means the same thing in both (write to `stdout`).

Revised plan:
The file needs to be `bgzip`ed, as it is used with `tabix` downstream. And `tabix` doesn't deal in regular `gzip`.