### PR TITLE
fix: custom-report: Replace indexes of ANN-field by keys

### DIFF
--- a/workflow/envs/rbt.yaml
+++ b/workflow/envs/rbt.yaml
@@ -3,4 +3,4 @@ channels:
   - conda-forge
 dependencies:
   - rust-bio-tools =0.39
-  - bcftools =1.12
+  - bcftools =1.14

--- a/workflow/envs/rbt.yaml
+++ b/workflow/envs/rbt.yaml
@@ -2,5 +2,5 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - rust-bio-tools =0.38
+  - rust-bio-tools =0.39
   - bcftools =1.12

--- a/workflow/resources/custom-table-report.js
+++ b/workflow/resources/custom-table-report.js
@@ -65,7 +65,7 @@ $(document).ready(function () {
                 if (transcript_hgvsc !== undefined) {
                     transcript = transcript_hgvsc.split(":")[0]
                     hgvs = transcript_hgvsc.split(":")[1]
-                    $('#Button'+ j).append('<a class="dropdown-item" href="https://varseak.bio/ssp.php?gene=' + gene + '&transcript='+ transcript +'&variant=&hgvs='+ hgsv +'" target="_blank">varSEAK Splice Site Prediction</a>');
+                    $('#Button'+ j).append('<a class="dropdown-item" href="https://varseak.bio/ssp.php?gene=' + gene + '&transcript='+ transcript +'&variant=&hgvs='+ hgvs +'" target="_blank">varSEAK Splice Site Prediction</a>');
                 }
             }
             var ensembl_idx = ANN_DESCRIPTION.indexOf("Gene")+1

--- a/workflow/resources/custom-table-report.js
+++ b/workflow/resources/custom-table-report.js
@@ -1,7 +1,7 @@
 let score_thresholds = {}
 score_thresholds["PolyPhen"] = { "Benign": [0, 0.149], "Possibly Damaging": [0.15, 0.849], "Probably Damaging": [0.85, 1] }
 score_thresholds["SIFT"] = {"Benign": [0, 0.05], "Damaging": [0.051, 1] }
-score_thresholds["REVEL"] = {"Malign": [0, 0.5], "Benign": [0.501, 1]}
+score_thresholds["REVEL"] = {"Likely Benign": [0, 0.5], "Likely Malign": [0.501, 1]}
 
 let score_scales = {}
 score_scales["SIFT"] = { "colors": ["#2ba6cb", "#ff5555"], "entries": ["Benign", "Damaging"] }

--- a/workflow/resources/custom-table-report.js
+++ b/workflow/resources/custom-table-report.js
@@ -45,7 +45,8 @@ $(document).ready(function () {
             var linkout_button = true
             $('#ann-sidebar').append('<td id="Linkout' + j +'">')
             $('#Linkout'+ j).append('<div id="Div' + j +'" class="dropdown show">')
-            gene_field = 'ann[' + j + '][4]'
+            var gene_index = ANN_DESCRIPTION.indexOf("SYMBOL")+1
+            gene_field = 'ann[' + j + '][' + gene_index + ']'
             gene = $(that).data(gene_field)
             if (gene !== undefined) {
                 linkout_button = create_linkout_button(linkout_button, j);
@@ -58,15 +59,17 @@ $(document).ready(function () {
                 $('#Button'+ j).append('<a class="dropdown-item" href="https://search.cancervariants.org/#'+ gene +'" target="_blank">MetaKB</a>');
                 $('#Button'+ j).append('<a class="dropdown-item" href="https://www.proteinatlas.org/search/'+ gene +'" target="_blank">The Human Protein Atlas</a>');
                 $('#Button'+ j).append('<a class="dropdown-item" href="https://varseak.bio/search.php?gene='+ gene +'" target="_blank">varSEAK Variant Table</a>');
-                transcript_hgsv_field = 'ann[' + j + '][11]'
-                transcript_hgsv = $(that).data(transcript_hgsv_field)
-                if (transcript_hgsv !== undefined) {
-                    transcript = transcript_hgsv.split(":")[0]
-                    hgsv = transcript_hgsv.split(":")[1]
+                var hgvsc_index = ANN_DESCRIPTION.indexOf("HGVSc")+1
+                transcript_hgvsc_field = 'ann[' + j + '][' + hgvsc_index + ']'
+                transcript_hgvsc = $(that).data(transcript_hgvsc_field)
+                if (transcript_hgvsc !== undefined) {
+                    transcript = transcript_hgvsc.split(":")[0]
+                    hgvs = transcript_hgvsc.split(":")[1]
                     $('#Button'+ j).append('<a class="dropdown-item" href="https://varseak.bio/ssp.php?gene=' + gene + '&transcript='+ transcript +'&variant=&hgvs='+ hgsv +'" target="_blank">varSEAK Splice Site Prediction</a>');
                 }
             }
-            ensembl_field = 'ann[' + j + '][5]'
+            var ensembl_idx = ANN_DESCRIPTION.indexOf("Gene")+1
+            ensembl_field = 'ann[' + j + '][' + ensembl_idx + ']'
             ensembl_id = $(that).data(ensembl_field)
             if (ensembl_id !== undefined) {
                 create_linkout_button(linkout_button, j)

--- a/workflow/resources/custom-table-report.js
+++ b/workflow/resources/custom-table-report.js
@@ -18,24 +18,24 @@ $(document).ready(function () {
         var polyphen_scores = []
         var revel_scores = []
         for (let j = 1; j <= ann_length; j++) {
-            var transcript_index = ANN_DESCRIPTION.indexOf("Feature")
+            var transcript_index = ANN_DESCRIPTION.indexOf("Feature")+1
             var transcript = $(that).data('ann[' + j + '][' + transcript_index + ']')
-            sift_index = ANN_DESCRIPTION.indexOf("SIFT")
+            sift_index = ANN_DESCRIPTION.indexOf("SIFT")+1
             sift_score = $(that).data('ann[' + j + ']['+ sift_index + ']')
             if (sift_score != "" && sift_score !== undefined) {
                 sift_score = sift_score.split("(")[1].slice(0, -1)
                 sift_scores = parse_score(sift_scores, sift_score, "SIFT", transcript)
             }
 
-            var polyphen_index = ANN_DESCRIPTION.indexOf("PolyPhen")
+            var polyphen_index = ANN_DESCRIPTION.indexOf("PolyPhen")+1
             var polyphen_score = $(that).data('ann[' + j + ']['+ polyphen_index + ']')
             if (polyphen_score != "" && polyphen_score !== undefined) {
                 polyphen_score = polyphen_score.split("(")[1].slice(0, -1)
                 polyphen_scores = parse_score(polyphen_scores, polyphen_score, "PolyPhen", transcript)
             }
 
-            var revel_index = ANN_DESCRIPTION.indexOf("REVEL")
-            if (revel_index != -1) {
+            var revel_index = ANN_DESCRIPTION.indexOf("REVEL")+1
+            if (revel_index != 0) {
                 var revel_score = $(that).data('ann[' + j + ']['+ revel_index + ']')
                 if (revel_score != "" && revel_score !== undefined) {
                     revel_scores = parse_score(revel_scores, revel_score, "REVEL", transcript)

--- a/workflow/resources/custom-table-report.js
+++ b/workflow/resources/custom-table-report.js
@@ -18,22 +18,28 @@ $(document).ready(function () {
         var polyphen_scores = []
         var revel_scores = []
         for (let j = 1; j <= ann_length; j++) {
-            var transcript = $(that).data('ann[' + j + '][7]')
-            sift_score = $(that).data('ann[' + j + '][36]')
+            var transcript_index = ANN_DESCRIPTION.indexOf("Feature")
+            var transcript = $(that).data('ann[' + j + '][' + transcript_index + ']')
+            sift_index = ANN_DESCRIPTION.indexOf("SIFT")
+            sift_score = $(that).data('ann[' + j + ']['+ sift_index + ']')
             if (sift_score != "" && sift_score !== undefined) {
                 sift_score = sift_score.split("(")[1].slice(0, -1)
                 sift_scores = parse_score(sift_scores, sift_score, "SIFT", transcript)
             }
 
-            polyphen_score = $(that).data('ann[' + j + '][37]')
+            var polyphen_index = ANN_DESCRIPTION.indexOf("PolyPhen")
+            var polyphen_score = $(that).data('ann[' + j + ']['+ polyphen_index + ']')
             if (polyphen_score != "" && polyphen_score !== undefined) {
                 polyphen_score = polyphen_score.split("(")[1].slice(0, -1)
                 polyphen_scores = parse_score(polyphen_scores, polyphen_score, "PolyPhen", transcript)
             }
 
-            revel_score = $(that).data('ann[' + j + '][71]')
-            if (revel_score != "" && revel_score !== undefined) {
-                revel_scores = parse_score(revel_scores, revel_score, "REVEL", transcript)
+            var revel_index = ANN_DESCRIPTION.indexOf("REVEL")
+            if (revel_index != -1) {
+                var revel_score = $(that).data('ann[' + j + ']['+ revel_index + ']')
+                if (revel_score != "" && revel_score !== undefined) {
+                    revel_scores = parse_score(revel_scores, revel_score, "REVEL", transcript)
+                }
             }
 
             var linkout_button = true

--- a/workflow/resources/custom-table-report.js
+++ b/workflow/resources/custom-table-report.js
@@ -6,7 +6,7 @@ score_thresholds["REVEL"] = {"Likely Benign": [0, 0.5], "Likely Malign": [0.501,
 let score_scales = {}
 score_scales["SIFT"] = { "colors": ["#2ba6cb", "#ff5555"], "entries": ["Benign", "Damaging"] }
 score_scales["PolyPhen"] = { "colors": ["#2ba6cb", "#ffa3a3", "#ff5555"], "entries": ["Benign", "Possibly Damaging", "Probably Damaging"] }
-score_scales["REVEL"] = { "colors": ["#2ba6cb", "#ff5555"], "entries": ["Benign", "Malign"] }
+score_scales["REVEL"] = { "colors": ["#2ba6cb", "#ff5555"], "entries": ["Likely Benign", "Likely Malign"] }
 
 $(document).ready(function () {
     $("html").on('click', '.variant-row', function () {

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -510,9 +510,7 @@ def get_plugin_aux(plugin, index=False):
     if plugin in config["annotations"]["vep"]["plugins"]:
         if plugin == "REVEL":
             suffix = ".tbi" if index else ""
-            return "resources/{build}_revel_scores.tsv.gz{suffix}".format(
-                build=config["ref"]["build"], suffix=suffix
-            )
+            return "resources/revel_scores.tsv.gz{suffix}".format(suffix=suffix)
     return []
 
 
@@ -610,9 +608,9 @@ def get_tabix_params(wildcards):
     raise ValueError("Invalid format for tabix: {}".format(wildcards.format))
 
 
-def get_tabix_revel_params(wildcards):
+def get_tabix_revel_params():
     # Indexing of REVEL-score file where the column depends on the reference
-    column = 2 if wildcards.ref == "GRCh37" else 3
+    column = 2 if config["ref"]["build"] == "GRCh37" else 3
     return f"-f -s 1 -b {column} -e {column}"
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -608,9 +608,9 @@ def get_tabix_params(wildcards):
     if wildcards.format == "txt":
         return "-s 1 -b 2 -e 2"
     if wildcards.format == "tsv":
-        if config["ref"]["build"] == "GRCh37":
-            return "-f -s 1 -b 2 -e 2"
-        return "-f -s 1 -b 3 -e 3"
+        # Indexing of REVEL-score file where the column depends on the reference
+        column = 2 if config["ref"]["build"] == "GRCh37" else 3
+        return f"-f -s 1 -b {column} -e {column}"
     raise ValueError("Invalid format for tabix: {}".format(wildcards.format))
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -607,11 +607,13 @@ def get_tabix_params(wildcards):
         return "-p vcf"
     if wildcards.format == "txt":
         return "-s 1 -b 2 -e 2"
-    if wildcards.format == "tsv":
-        # Indexing of REVEL-score file where the column depends on the reference
-        column = 2 if config["ref"]["build"] == "GRCh37" else 3
-        return f"-f -s 1 -b {column} -e {column}"
     raise ValueError("Invalid format for tabix: {}".format(wildcards.format))
+
+
+def get_tabix_revel_params(wildcards):
+    # Indexing of REVEL-score file where the column depends on the reference
+    column = 2 if wildcards.ref == "GRCh37" else 3
+    return f"-f -s 1 -b {column} -e {column}"
 
 
 def get_fastqs(wc):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -608,6 +608,8 @@ def get_tabix_params(wildcards):
     if wildcards.format == "txt":
         return "-s 1 -b 2 -e 2"
     if wildcards.format == "tsv":
+        if config["ref"]["build"] == "GRCh37":
+            return "-f -s 1 -b 2 -e 2"
         return "-f -s 1 -b 3 -e 3"
     raise ValueError("Invalid format for tabix: {}".format(wildcards.format))
 

--- a/workflow/rules/plugins.smk
+++ b/workflow/rules/plugins.smk
@@ -11,18 +11,20 @@ rule process_revel_scores:
     input:
         "resources/revel_scores.zip",
     output:
-        "resources/{ref}_revel_scores.tsv.gz",
+        "resources/revel_scores.tsv.gz",
+    params:
+        build=config["ref"]["build"],
     log:
-        "logs/vep_plugins/process_{ref}_revel_scores.log",
+        "logs/vep_plugins/process_revel_scores.log",
     conda:
         "../envs/htslib.yaml"
     shell:
         """
         tmpfile=$(mktemp {resources.tmpdir}/revel_scores.XXXXXX)
         unzip -p {input} | tr "," "\t" | sed '1s/.*/#&/' | bgzip -c > $tmpfile
-        if [ "{wildcards.ref}" == "GRCh38" ] ; then
+        if [ "{params.build}" == "GRCh38" ] ; then
             zgrep -h -v ^#chr $tmpfile | awk '$3 != "." ' | sort -k1,1 -k3,3n - | cat <(zcat $tmpfile | head -n1) - | bgzip -c > {output}
-        elif [ "{wildcards.ref}" == "GRCh37" ] ; then
+        elif [ "{params.build}" == "GRCh37" ] ; then
             cat $tmpfile > {output}
         else
             echo "Annotation of REVEL scores only supported for GRCh37 or GRCh38" > {log}
@@ -33,10 +35,10 @@ rule process_revel_scores:
 
 use rule tabix_known_variants as tabix_revel_scores with:
     input:
-        "resources/{ref}_revel_scores.tsv.gz",
+        "resources/revel_scores.tsv.gz",
     output:
-        "resources/{ref}_revel_scores.tsv.gz.tbi",
+        "resources/revel_scores.tsv.gz.tbi",
     params:
-        get_tabix_revel_params,
+        get_tabix_revel_params(),
     log:
-        "logs/tabix/revel_{ref}.log",
+        "logs/tabix/revel.log",

--- a/workflow/rules/plugins.smk
+++ b/workflow/rules/plugins.smk
@@ -29,3 +29,14 @@ rule process_revel_scores:
             exit 125
         fi
         """
+
+
+use rule tabix_known_variants as tabix_revel_scores with:
+    input:
+        "resources/{ref}_revel_scores.tsv.gz",
+    output:
+        "resources/{ref}_revel_scores.tsv.gz.tbi",
+    params:
+        get_tabix_revel_params,
+    log:
+        "logs/tabix/revel_{ref}.log",

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -31,6 +31,8 @@ rule tabix_known_variants:
         "logs/tabix/{prefix}.{format}.log",
     params:
         get_tabix_params,
+    wildcard_constraints:
+        format=r"txt|vcf",
     cache: True
     wrapper:
         "0.59.2/bio/tabix"

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -31,8 +31,6 @@ rule tabix_known_variants:
         "logs/tabix/{prefix}.{format}.log",
     params:
         get_tabix_params,
-    wildcard_constraints:
-        format=r"txt|vcf",
     cache: True
     wrapper:
         "0.59.2/bio/tabix"


### PR DESCRIPTION
This PR updates to rbt 0.39 which allows to access the index of ANN-field entries by field names.
Also the REVEL-plot will be fixed where values being benign or malign were flipped.