### PR TITLE
fix: patch picard syntax usage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,8 @@ jobs:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-target-regions/config.yaml --use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache --conda-frontend mamba"
+        stagein: |
+          rm -rf .test/results
 
     - name: Test workflow (local FASTQs, no candidate filtering)
       uses: snakemake/snakemake-github-action@v1.24.0
@@ -68,6 +70,8 @@ jobs:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-no-candidate-filtering/config.yaml --dryrun --use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache --conda-frontend mamba"
+        stagein: |
+          rm -rf .test/results
 
     - name: Test workflow (local FASTQs primer)
       uses: snakemake/snakemake-github-action@v1.24.0
@@ -76,7 +80,7 @@ jobs:
         snakefile: workflow/Snakefile
         args: "--configfile .test/config_primers/config.yaml --use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache --conda-frontend mamba"
         stagein: |
-          rm -rf .test/resources .test/results
+          rm -rf .test/results
 
     - name: Test workflow (SRA FASTQs)
       uses: snakemake/snakemake-github-action@v1.24.0
@@ -85,4 +89,4 @@ jobs:
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-sra/config.yaml --show-failed-logs --use-conda -n -j 10 --conda-cleanup-pkgs cache --conda-frontend mamba"
         stagein: |
-          rm -rf .test/resources .test/results
+          rm -rf .test/results

--- a/.test/config-target-regions/config.yaml
+++ b/.test/config-target-regions/config.yaml
@@ -39,7 +39,7 @@ calling:
   freebayes:
     activate: true
   # See https://varlociraptor.github.io/docs/calling/#generic-variant-calling
-  scenario: config/scenario.yaml
+  scenario: config-target-regions/scenario.yaml
   # See http://snpeff.sourceforge.net/SnpSift.html#filter
   filter:
     candidates: "ANN['IMPACT'] != 'LOW'"

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -47,6 +47,7 @@ rule mark_duplicates:
             if is_activated("calc_consensus_reads")
             else "",
         ),
+        java_opts="-Dpicard.useLegacyParser=false",
     wrapper:
         "v1.2.0/bio/picard/markduplicates"
 


### PR DESCRIPTION
as a side-effect, this PR also turn two GitHub Action Test steps back on, that were previously skipped because all requested `.test/results` were still around from previous steps. These are now removed via a `stagein:` command. Also, we do not remove `.test/resources` in any of those `stagein:` commands any more, as that would be truly redundant testing of the resources download and processing.