### PR TITLE
fix: picard syntax in configs and in the mark_duplicates rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@
 !.editorconfig
 !.travis.yml
 !.test
-!.test/data
+!.test/**/*
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,7 @@
 !workflow/rules/*
 !workflow/rules/annotation/*
 !workflow/resources/*
-!config.yaml
-!samples.tsv
-!scenario.yaml
+!config/*
 !LICENSE
 !README.md
 !.gitignore

--- a/.test/config-chm-eval/config.yaml
+++ b/.test/config-chm-eval/config.yaml
@@ -123,7 +123,7 @@ annotations:
 params:
   cutadapt: ""
   picard:
-    MarkDuplicates: "VALIDATION_STRINGENCY=lenient"
+    MarkDuplicates: "--VALIDATION_STRINGENCY lenient"
   gatk:
     BaseRecalibrator: ""
   varlociraptor:

--- a/.test/config-giab/config.yaml
+++ b/.test/config-giab/config.yaml
@@ -125,7 +125,7 @@ annotations:
 params:
   cutadapt: ""
   picard:
-    MarkDuplicates: "VALIDATION_STRINGENCY=LENIENT"
+    MarkDuplicates: "--VALIDATION_STRINGENCY LENIENT"
   gatk:
     BaseRecalibrator: ""
     applyBQSR: ""

--- a/.test/config-simple/config.yaml
+++ b/.test/config-simple/config.yaml
@@ -71,7 +71,7 @@ annotations:
 params:
   cutadapt: ""
   picard:
-    MarkDuplicates: ""
+    MarkDuplicates: "--VALIDATION_STRINGENCY LENIENT"
   gatk:
     BaseRecalibrator: ""
     applyBQSR: ""

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -160,7 +160,7 @@ annotations:
 params:
   cutadapt: ""
   picard:
-    MarkDuplicates: "VALIDATION_STRINGENCY=LENIENT"
+    MarkDuplicates: "--VALIDATION_STRINGENCY LENIENT"
   gatk:
     BaseRecalibrator: ""
     applyBQSR: ""

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -318,17 +318,17 @@ def get_primer_regions(wc):
 
 
 def get_markduplicates_extra(wc):
-    c=config["params"]["picard"]["MarkDuplicates"]
+    c = config["params"]["picard"]["MarkDuplicates"]
 
     if units.loc[wc.sample]["umis"].isnull().any():
-        b=""
+        b = ""
     else:
-        b="--BARCODE_TAG RX"
+        b = "--BARCODE_TAG RX"
 
     if is_activated("calc_consensus_reads"):
-        d="--TAG_DUPLICATE_SET_MEMBERS true"
+        d = "--TAG_DUPLICATE_SET_MEMBERS true"
     else:
-        d=""
+        d = ""
 
     return f"{c} {b} {d}"
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -317,6 +317,22 @@ def get_primer_regions(wc):
     return "results/primers/uniform_primer_regions.tsv"
 
 
+def get_markduplicates_extra(wc):
+    c=config["params"]["picard"]["MarkDuplicates"]
+
+    if units.loc[wc.sample]["umis"].isnull().any():
+        b=""
+    else:
+        b="--BARCODE_TAG RX"
+
+    if is_activated("calc_consensus_reads"):
+        d="--TAG_DUPLICATE_SET_MEMBERS true"
+    else:
+        d=""
+
+    return f"{c} {b} {d}"
+
+
 def get_group_bams(wildcards, bai=False):
     ext = "bai" if bai else "bam"
     if is_activated("primers/trimming") and not group_is_paired_end(wildcards.group):

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -40,15 +40,7 @@ rule mark_duplicates:
     log:
         "logs/picard/dedup/{sample}.log",
     params:
-        extra=lambda wc: "{c} {b} {d}".format(
-            c=config["params"]["picard"]["MarkDuplicates"],
-            b=""
-            if units.loc[wc.sample]["umis"].isnull().any()
-            else "--BARCODE_TAG RX",
-            d="--TAG_DUPLICATE_SET_MEMBERS true"
-            if is_activated("calc_consensus_reads")
-            else "",
-        ),
+        extra=get_markduplicates_extra,
     wrapper:
         "v1.2.0/bio/picard/markduplicates"
 

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -42,12 +42,11 @@ rule mark_duplicates:
     params:
         extra=lambda wc: "{c} {b} {d}".format(
             c=config["params"]["picard"]["MarkDuplicates"],
-            b="" if units.loc[wc.sample]["umis"].isnull().any() else "BARCODE_TAG=RX",
-            d="TAG_DUPLICATE_SET_MEMBERS=true"
+            b="" if units.loc[wc.sample]["umis"].isnull().any() else "--BARCODE_TAG RX",
+            d="--TAG_DUPLICATE_SET_MEMBERS true"
             if is_activated("calc_consensus_reads")
             else "",
         ),
-        java_opts="-Dpicard.useLegacyParser=false",
     wrapper:
         "v1.2.0/bio/picard/markduplicates"
 

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -42,7 +42,9 @@ rule mark_duplicates:
     params:
         extra=lambda wc: "{c} {b} {d}".format(
             c=config["params"]["picard"]["MarkDuplicates"],
-            b="" if units.loc[wc.sample]["umis"].isnull().any() else "--BARCODE_TAG RX",
+            b=""
+            if units.loc[wc.sample]["umis"].isnull().any()
+            else "--BARCODE_TAG RX",
             d="--TAG_DUPLICATE_SET_MEMBERS true"
             if is_activated("calc_consensus_reads")
             else "",


### PR DESCRIPTION
As a side-effect, this also cleans up the `.gitignore` file a bit.