### PR TITLE
fix: make the fasta index an explicit input of rule filter_group_regions

### DIFF
--- a/workflow/rules/regions.smk
+++ b/workflow/rules/regions.smk
@@ -65,3 +65,4 @@ rule build_excluded_group_regions:
         "(complementBed -i {input.target_regions} -g <(head "
         "-n {params.chroms} {input.genome_index} | cut "
         "-f 1,2 | sort -k1,1 -k 2,2n) > {output}) 2> {log}"
+

--- a/workflow/rules/regions.smk
+++ b/workflow/rules/regions.smk
@@ -33,8 +33,9 @@ rule merge_group_regions:
 
 rule filter_group_regions:
     input:
-        "results/regions/{group}.target_regions.bed",
+        regions="results/regions/{group}.target_regions.bed",
         predefined=config["targets_bed"] if "targets_bed" in config else [],
+        fai="resources/genome.fasta.fai",
     output:
         "results/regions/{group}.target_regions.filtered.bed",
     params:
@@ -43,7 +44,7 @@ rule filter_group_regions:
     log:
         "logs/regions/{group}.target_regions.filtered.log",
     shell:
-        "cat {input} | grep -f <(head -n {params.chroms} resources/genome.fasta.fai | "
+        "cat {input.regions} {input.predefined} | grep -f <(head -n {params.chroms} {input.fai} | "
         'awk \'{{print "^"$1"\\t"}}\') {params.filter_targets} '
         "> {output} 2> {log}"
 

--- a/workflow/rules/regions.smk
+++ b/workflow/rules/regions.smk
@@ -65,4 +65,3 @@ rule build_excluded_group_regions:
         "(complementBed -i {input.target_regions} -g <(head "
         "-n {params.chroms} {input.genome_index} | cut "
         "-f 1,2 | sort -k1,1 -k 2,2n) > {output}) 2> {log}"
-


### PR DESCRIPTION
Previously, this was only an implicit requirement and changing the path to that file would lead to errors that are difficult to trace.