### PR TITLE
fix: Handle multiple samples

### DIFF
--- a/workflow/envs/datavzrd.yaml
+++ b/workflow/envs/datavzrd.yaml
@@ -1,4 +1,4 @@
 channels:
   - conda-forge
 dependencies:
-  - datavzrd =1.9
+  - datavzrd =1.10

--- a/workflow/envs/pandas.yaml
+++ b/workflow/envs/pandas.yaml
@@ -2,4 +2,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - pandas =1.0.3
+  - pandas =1.4
+  - python =3.10

--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -71,6 +71,7 @@ datasets:
           ?group:
             column: hgvsp
             table-row: ?f"{group}-coding/hgvsp"
+            optional: true
 
   ?for group, path in zip(params.groups, params.coding_calls):
     ?f"{group}-coding":

--- a/workflow/scripts/oncoprint.py
+++ b/workflow/scripts/oncoprint.py
@@ -37,10 +37,10 @@ def sort_by_recurrence(matrix, no_occurence_check_func):
     return matrix
 
 
-def add_missing_groups(matrix, groups):
+def add_missing_groups(matrix, groups, index_mate):
     for group in groups:
-        if group not in matrix.columns:
-            matrix[group] = 0
+        if (index_mate, group) not in matrix.columns:
+            matrix[(index_mate, group)] = 0
     return matrix
 
 
@@ -55,8 +55,7 @@ def gene_oncoprint(calls):
         matrix = grouped.set_index(["symbol", "consequence", "group"]).unstack(
             level="group"
         )
-        matrix = add_missing_groups(matrix, snakemake.params.groups)
-
+        matrix = add_missing_groups(matrix, snakemake.params.groups, "vartype")
         matrix.columns = matrix.columns.droplevel(0)  # remove superfluous header
         if len(matrix.columns) > 1:
             # sort by recurrence
@@ -74,7 +73,8 @@ def variant_oncoprint(gene_calls):
         .unstack(level="group")
         .fillna(0)
     )
-    matrix = add_missing_groups(matrix, snakemake.params.groups)
+
+    matrix = add_missing_groups(matrix, snakemake.params.groups, "exists")
     matrix.columns = matrix.columns.droplevel(0)  # remove superfluous header
 
     if len(matrix.columns) > 1:

--- a/workflow/scripts/oncoprint.py
+++ b/workflow/scripts/oncoprint.py
@@ -34,6 +34,14 @@ def sort_by_recurrence(matrix, no_occurence_check_func):
     matrix = matrix.sort_values("nocalls", ascending=False).drop(
         labels=["nocalls"], axis="columns"
     )
+    return matrix
+
+
+def add_missing_groups(matrix, groups):
+    for group in groups:
+        if group not in matrix.columns:
+            matrix[group] = 0
+    return matrix
 
 
 def gene_oncoprint(calls):
@@ -47,6 +55,7 @@ def gene_oncoprint(calls):
         matrix = grouped.set_index(["symbol", "consequence", "group"]).unstack(
             level="group"
         )
+        matrix = add_missing_groups(matrix, snakemake.params.groups)
 
         matrix.columns = matrix.columns.droplevel(0)  # remove superfluous header
         if len(matrix.columns) > 1:
@@ -65,6 +74,7 @@ def variant_oncoprint(gene_calls):
         .unstack(level="group")
         .fillna(0)
     )
+    matrix = add_missing_groups(matrix, snakemake.params.groups)
     matrix.columns = matrix.columns.droplevel(0)  # remove superfluous header
 
     if len(matrix.columns) > 1:


### PR DESCRIPTION
This PR fixes an issue where no value is returned when multiple samples are processed.
Additionally, when for some samples no variants were found this results in an invalid oncoprint table
This has been fixed by adding missing columns to the corresponding table.
Finally, the datavzrd template needed to be updated in order to handle optional linkout introduced by datavzrd.