### PR TITLE
fix: defer final output determination to DAG phase

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -44,7 +44,7 @@ if is_activated("report/stratify"):
 
 rule all:
     input:
-        get_final_output(),
+        get_final_output,
 
 
 rule benchmark:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -70,7 +70,7 @@ primer_panels = (
 )
 
 
-def get_final_output():
+def get_final_output(wildcards):
 
     final_output = expand(
         "results/qc/multiqc/{group}.html",


### PR DESCRIPTION
This allows to modify config after loading the workflow as a module