### PR TITLE
feat: enhance oncoprint report

### DIFF
--- a/workflow/envs/datavzrd.yaml
+++ b/workflow/envs/datavzrd.yaml
@@ -1,4 +1,4 @@
 channels:
   - conda-forge
 dependencies:
-  - datavzrd =1.16
+  - datavzrd =1.17

--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -22,35 +22,55 @@ __definitions__:
         /(\d+):[gG]\.(\d+)_(\d+)ins([GCTAgcta]+)$/,
         /(\d+):[gG]\.(\d+)_(\d+)ins(\d+)_(\d+)inv$/,
       ];
-      for (let i = 0; i < regex.length; i++) {{
-        const match = row.hgvsg.match(regex[i]);
-        if ( match ) {{
-          switch (i) {{
-            // SNV
-            case 0:
-              descriptor = match.splice(1).join(":");
+      const hgvsgs = row.hgvsg.split(',')
+      const descriptors = []
+      for (let j = 0; j < hgvsgs.length; j++) {{
+        for (let i = 0; i < regex.length; i++) {{
+          const match = hgvsgs[j].match(regex[i]);
+          if ( match ) {{
+            switch (i) {{
+              // SNV
+              case 0:
+                descriptor = match.splice(1).join(":");
+                break;
+              // Deletion
+              case 3:
+                del_size = match[3]-match[2]+1;
+                descriptor = [match[1], match[2], del_size, ""].join(":");
+                break;
+              // Insertion
+              case 4:
+                descriptor = [match[1], match[3], "", match[4]].join(":");
+                break;
+              default:
+                descriptor = null;
+            }}
+            if (descriptor) {{
+              descriptors.push(descriptor)
+              //return `<a href="${{url}}${{descriptor}}" target="_blank">${{hgvsp}}</a>`;
+            }} else {{
+              // End for-loop
               break;
-            // Deletion
-            case 3:
-              del_size = match[3]-match[2]+1;
-              descriptor = [match[1], match[2], del_size, ""].join(":");
-              break;
-            // Insertion
-            case 4:
-              descriptor = [match[1], match[3], "", match[4]].join(":");
-              break;
-            default:
-              descriptor = null;
-          }}
-          if (descriptor) {{
-            return `<a href="${{url}}${{descriptor}}" target="_blank">${{hgvsp}}</a>`;
-          }} else {{
-            // End for-loop
-            break;
+            }}
           }}
         }}
       }}
-      return `${{hgvsp}}`;
+      if ( descriptors.length == 0) {{
+        return `${{hgvsp}}`;
+      }}
+      else if ( descriptors.length == 1) {{
+        return `<a href="${{url}}${{descriptors[0]}}" target="_blank">${{hgvsp}}</a>`;
+      }}
+      else {{
+        dropdown = `<div class="dropdown show">`
+        dropdown += `<a class="btn btn-secondary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">${{hgvsp}}</a>`
+        dropdown += `<div class="dropdown-menu" aria-labelledby="dropdownMenuLink">`
+        for (let i = 0; i < descriptors.length; i++) {{
+          dropdown +=`<a class="dropdown-item" href="${{url}}${{descriptors[i]}}" target="_blank">${{hgvsp}} (${{descriptors[i]}})</a>`
+        }}
+        dropdown += `</div></div>`
+        return dropdown
+      }}
     }}
     """
 
@@ -126,6 +146,8 @@ views:
                   scale: ordinal
                   color-scheme: paired
                   aux-domain-columns: ?list(params.groups)
+          hgvsg:
+            display-mode: hidden
 
   ?for group in params.groups:
     ?f"{group}-coding":

--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -24,6 +24,7 @@ __definitions__:
       ];
       const hgvsgs = row.hgvsg.split(',')
       const descriptors = []
+      const hgvsgs_matched = []
       for (let j = 0; j < hgvsgs.length; j++) {{
         for (let i = 0; i < regex.length; i++) {{
           const match = hgvsgs[j].match(regex[i]);
@@ -47,11 +48,10 @@ __definitions__:
             }}
             if (descriptor) {{
               descriptors.push(descriptor)
+              hgvsgs_matched.push(hgvsgs[j])
               //return `<a href="${{url}}${{descriptor}}" target="_blank">${{hgvsp}}</a>`;
-            }} else {{
-              // End for-loop
-              break;
             }}
+            break;
           }}
         }}
       }}
@@ -66,7 +66,7 @@ __definitions__:
         dropdown += `<a class="btn btn-secondary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">${{hgvsp}}</a>`
         dropdown += `<div class="dropdown-menu" aria-labelledby="dropdownMenuLink">`
         for (let i = 0; i < descriptors.length; i++) {{
-          dropdown +=`<a class="dropdown-item" href="${{url}}${{descriptors[i]}}" target="_blank">${{hgvsp}} (${{descriptors[i]}})</a>`
+          dropdown +=`<a class="dropdown-item" href="${{url}}${{descriptors[i]}}" target="_blank">${{hgvsp}} (${{hgvsgs_matched[i]}})</a>`
         }}
         dropdown += `</div></div>`
         return dropdown

--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -49,7 +49,6 @@ __definitions__:
             if (descriptor) {{
               descriptors.push(descriptor)
               hgvsgs_matched.push(hgvsgs[j])
-              //return `<a href="${{url}}${{descriptor}}" target="_blank">${{hgvsp}}</a>`;
             }}
             break;
           }}

--- a/workflow/scripts/oncoprint.py
+++ b/workflow/scripts/oncoprint.py
@@ -9,14 +9,18 @@ import pandas as pd
 import numpy as np
 
 
-def join_gene_variants(df):
-    vartypes = ",".join(pd.unique(df["vartype"]))
+def join_group_consequences(df):
     consequences = ",".join(
         np.sort(pd.unique(df["consequence"].str.split(",").explode()))
     )
+    df.loc[:, "consequence"] = consequences
+    return df
+
+
+def join_gene_vartypes(df):
+    vartypes = ",".join(pd.unique(df["vartype"]))
     df = df.iloc[:1]
     df.loc[:, "vartype"] = vartypes
-    df.loc[:, "consequence"] = consequences
     return df
 
 
@@ -48,9 +52,12 @@ def gene_oncoprint(calls):
     calls = calls[["group", "symbol", "vartype", "consequence"]]
     if not calls.empty:
         grouped = (
-            calls.drop_duplicates()
+            calls.drop_duplicates().groupby(["symbol"]).apply(join_group_consequences)
+        )
+        grouped = (
+            grouped.drop_duplicates()
             .groupby(["group", "symbol"])
-            .apply(join_gene_variants)
+            .apply(join_gene_vartypes)
         )
         matrix = grouped.set_index(["symbol", "consequence", "group"]).unstack(
             level="group"
@@ -68,9 +75,8 @@ def gene_oncoprint(calls):
 def variant_oncoprint(gene_calls):
     gene_calls = gene_calls[["group", "hgvsp", "hgvsg", "consequence"]]
     gene_calls.loc[:, "exists"] = "X"
-    matrix = (
-        gene_calls.set_index(["hgvsp", "hgvsg", "consequence", "group"])
-        .unstack(level="group")
+    matrix = gene_calls.set_index(["hgvsp", "hgvsg", "consequence", "group"]).unstack(
+        level="group"
     )
 
     matrix = add_missing_groups(matrix, snakemake.params.groups, "exists")


### PR DESCRIPTION
Currently the oncoprint in the datavzrd report has some short comings.
This includes multiple occurences of the same gene in the `gene_oncoprint` when different samples have variants on the same gene.
This will now be solved by joining these rows into a single one by merging the consequences of all samples.

In addition the variant oncoprint shows multiple rows for duplicated HGVSp values in case the HGVSg value differs.
In ordner to only show a single row per HGVSp value the HGVSg column will be hidden and the entries of HGVSp column are replaced by dropdown menus showing varsome-linkouts for each different HGVSg entry.  