### PR TITLE
fix: correctly filter target regions

### DIFF
--- a/workflow/rules/regions.smk
+++ b/workflow/rules/regions.smk
@@ -81,7 +81,7 @@ rule filter_group_regions:
     log:
         "logs/regions/{group}.{regions_type}_regions.filtered.log",
     shell:
-        "cat {input.regions} {input.predefined} | grep -f <(head -n {params.chroms} {input.fai} | "
+        "cat {input.regions} | grep -f <(head -n {params.chroms} {input.fai} | "
         'awk \'{{print "^"$1"\\t"}}\') {params.filter_targets} | sort -k1,1 -k2,2n '
         "> {output} 2> {log}"
 


### PR DESCRIPTION
The filter group regions filters covered regions against a set of target regions if existing.
If the target regions file exists filtering is done by `bedtools intersect` defined by `{params.filter_targets}`.
In its current implementation the covered regions and target regions are being concatenated.
This way we would end up with the whole set of target regions but also duplicate entries.
