### PR TITLE
feat: Ordering gene oncoprint rows based on annotation label

### DIFF
--- a/workflow/envs/datavzrd.yaml
+++ b/workflow/envs/datavzrd.yaml
@@ -1,4 +1,4 @@
 channels:
   - conda-forge
 dependencies:
-  - datavzrd =2.2
+  - datavzrd =2.6

--- a/workflow/envs/oncoprint.yaml
+++ b/workflow/envs/oncoprint.yaml
@@ -1,0 +1,8 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - pandas =1.4
+  - python =3.10
+  - scikit-learn =1.1.2
+  - statsmodels =0.13.2

--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -84,7 +84,7 @@ datasets:
         gene details:
           column: symbol
           view: "overview-{value}"
-    ?for label in params.group_annotations.columns.values:
+    ?for label in params.labels.index.values:
       ?label:
         path: ?os.path.join(params.oncoprint_sorted_datasets, f"{label}.tsv")
         separator: "\t"
@@ -112,7 +112,9 @@ datasets:
 
 views:
   ?if params.gene_oncoprint:
-    ?for view in ["gene-oncoprint"] + list(params.group_annotations.columns.values):
+    ?for view in ["gene-oncoprint"] + list(params.labels.index.values):
+      __variables__:
+        labels: ?params.group_annotations.columns.values if view == "gene-oncoprint" else [view]
       ?"overview" if view == "gene-oncoprint" else f"by {view}":
         ?if view == "gene-oncoprint":
           desc: |
@@ -130,7 +132,7 @@ views:
         dataset: ?view
         render-table:
           headers:
-            ?for i, annotation in enumerate(params.group_annotations.columns.values):
+            ?for i, annotation in enumerate(labels):
               ?i + 1:
                 label: ?annotation
                 plot:
@@ -152,6 +154,16 @@ views:
                     scale: ordinal
                     color-scheme: paired
                     aux-domain-columns: ?list(params.groups)
+            p-value dependency:
+              plot:
+                ticks:
+                  scale: linear
+              optional: true
+            FDR dependency:
+              plot:
+                ticks:
+                  scale: linear
+              optional: true
     
     ?for gene, path in params.variant_oncoprints:
       ?f"overview-{gene}":

--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -3,6 +3,7 @@ name: ?f"Variant calls {wildcards.event}"
 default-view: ?"overview" if input.variant_oncoprints else f"{params.groups[0]}-coding"
 
 __definitions__:
+  - import os
   - |
     def read_file(path):
         return open(path, 'r').read()
@@ -83,6 +84,11 @@ datasets:
         gene details:
           column: symbol
           view: "overview-{value}"
+    ?for label in params.group_annotations.columns.values:
+      ?label:
+        path: ?os.path.join(params.oncoprint_sorted_datasets, f"{label}.tsv")
+        separator: "\t"
+        headers: 2
     ?for gene, path in params.variant_oncoprints:
       ?f"variant-oncoprint-{gene}":
         path: ?path
@@ -106,35 +112,46 @@ datasets:
 
 views:
   ?if params.gene_oncoprint:
-    overview:
-      desc: |
-        Overview table showing all discovered variants in all samples. Use link
-        button to jump to detail views for the respective genes.
-      dataset: gene-oncoprint
-      render-table:
-        headers:
-          ?for i, annotation in enumerate(params.group_annotations.columns.values):
-            ?i + 1:
-              label: ?annotation
+    ?for view in ["gene-oncoprint"] + list(params.group_annotations.columns.values):
+      ?"overview" if view == "gene-oncoprint" else f"by {view}":
+        ?if view == "gene-oncoprint":
+          desc: |
+            Overview table showing all discovered variants in all samples. Use link
+            button to jump to detail views for the respective genes.
+        ?else:
+          desc: |
+            ?f"""
+            Rows are sorted by their statistical dependency on {view}, which is determined by a 
+            [Chi² test](https://scikit-learn.org/stable/modules/generated/sklearn.feature_selection.chi2.html).
+            The corresponding p-value and Benjamini-Hochberg corrected FDR is shown in the last two columns.
+            They represent the probability to observe an at least as strong dependency by chance.
+            Rows with highest dependency are shown first.
+            """
+        dataset: ?view
+        render-table:
+          headers:
+            ?for i, annotation in enumerate(params.group_annotations.columns.values):
+              ?i + 1:
+                label: ?annotation
+                plot:
+                  heatmap:
+                    scale: ordinal
+                    color-scheme: category20
+          columns:
+            symbol:
+              link-to-url: https://www.ensembl.org/Homo_sapiens/Gene/Summary?g={value}
+            consequence:
               plot:
                 heatmap:
                   scale: ordinal
                   color-scheme: category20
-        columns:
-          symbol:
-            link-to-url: https://www.ensembl.org/Homo_sapiens/Gene/Summary?g={value}
-          consequence:
-            plot:
-              heatmap:
-                scale: ordinal
-                color-scheme: category20
-          ?for group in params.groups:
-            ?group:
-              plot:
-                heatmap:
-                  scale: ordinal
-                  color-scheme: paired
-                  aux-domain-columns: ?list(params.groups)
+            ?for group in params.groups:
+              ?group:
+                plot:
+                  heatmap:
+                    scale: ordinal
+                    color-scheme: paired
+                    aux-domain-columns: ?list(params.groups)
     
     ?for gene, path in params.variant_oncoprints:
       ?f"overview-{gene}":

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -95,6 +95,11 @@ primer_panels = (
     else None
 )
 
+def get_annotation_labels():
+    nunique = group_annotation.nunique()
+    cols_to_drop = nunique[nunique == 1].index
+    return group_annotation.drop(cols_to_drop, axis=1).T
+
 
 def get_final_output(wildcards):
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -95,6 +95,7 @@ primer_panels = (
     else None
 )
 
+
 def get_heterogeneous_labels():
     nunique = group_annotation.nunique()
     cols_to_drop = nunique[nunique == 1].index

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -95,7 +95,7 @@ primer_panels = (
     else None
 )
 
-def get_annotation_labels():
+def get_heterogeneous_labels():
     nunique = group_annotation.nunique()
     cols_to_drop = nunique[nunique == 1].index
     return group_annotation.drop(cols_to_drop, axis=1).T

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -15,6 +15,7 @@ rule split_call_tables:
     script:
         "../scripts/split-call-tables.py"
 
+
 rule prepare_oncoprint:
     input:
         calls=get_oncoprint_input,
@@ -60,6 +61,7 @@ rule render_datavzrd_config:
         varsome_url=get_varsome_url(),
         samples=samples,
         group_annotations=group_annotation,
+        oncoprint_sorted_datasets="results/tables/oncoprints/{batch}.{event}/label_sortings/",
     log:
         "logs/datavzrd_render/{batch}.{event}.log",
     template_engine:

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -32,7 +32,7 @@ rule prepare_oncoprint:
         "logs/prepare_oncoprint/{batch}.{event}.log",
     params:
         groups=get_report_batch,
-        labels=get_annotation_labels(),
+        labels=get_heterogeneous_labels(),
     conda:
         "../envs/oncoprint.yaml"
     script:
@@ -62,7 +62,7 @@ rule render_datavzrd_config:
         varsome_url=get_varsome_url(),
         samples=samples,
         group_annotations=group_annotation,
-        labels=get_annotation_labels(),
+        labels=get_heterogeneous_labels(),
         oncoprint_sorted_datasets="results/tables/oncoprints/{batch}.{event}/label_sortings/",
     log:
         "logs/datavzrd_render/{batch}.{event}.log",

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -15,13 +15,15 @@ rule split_call_tables:
     script:
         "../scripts/split-call-tables.py"
 
-
 rule prepare_oncoprint:
     input:
         calls=get_oncoprint_input,
         group_annotation=config.get("groups", []),
     output:
         gene_oncoprint="results/tables/oncoprints/{batch}.{event}/gene-oncoprint.tsv",
+        gene_oncoprint_sortings=directory(
+            "results/tables/oncoprints/{batch}.{event}/label_sortings/"
+        ),
         variant_oncoprints=directory(
             "results/tables/oncoprints/{batch}.{event}/variant-oncoprints"
         ),
@@ -30,7 +32,7 @@ rule prepare_oncoprint:
     params:
         groups=get_report_batch,
     conda:
-        "../envs/pandas.yaml"
+        "../envs/oncoprint.yaml"
     script:
         "../scripts/oncoprint.py"
 

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -32,6 +32,7 @@ rule prepare_oncoprint:
         "logs/prepare_oncoprint/{batch}.{event}.log",
     params:
         groups=get_report_batch,
+        labels=get_annotation_labels(),
     conda:
         "../envs/oncoprint.yaml"
     script:
@@ -61,6 +62,7 @@ rule render_datavzrd_config:
         varsome_url=get_varsome_url(),
         samples=samples,
         group_annotations=group_annotation,
+        labels=get_annotation_labels(),
         oncoprint_sorted_datasets="results/tables/oncoprints/{batch}.{event}/label_sortings/",
     log:
         "logs/datavzrd_render/{batch}.{event}.log",

--- a/workflow/scripts/oncoprint.py
+++ b/workflow/scripts/oncoprint.py
@@ -153,7 +153,7 @@ def sort_oncoprint_labels(data):
     labels = labels_df.index
 
     for label_idx, label in enumerate(labels):
-        outdata = data.copy(deep=True)
+        outdata = data
         if not data.empty:
             feature_matrix = data.reset_index(drop=True).T.copy()
             feature_matrix[~pd.isna(feature_matrix)] = True

--- a/workflow/scripts/oncoprint.py
+++ b/workflow/scripts/oncoprint.py
@@ -153,10 +153,8 @@ def sort_oncoprint_labels(data):
     labels = labels_df.index
 
     for label_idx, label in enumerate(labels):
-        outpath = os.path.join(snakemake.output.gene_oncoprint_sortings, f"{label}.tsv")
-        if data.empty:
-            store(data, outpath, labels_df, label_idx=label_idx)
-        else:
+        outdata = data.copy(deep=True)
+        if not data.empty:
             feature_matrix = data.reset_index(drop=True).T.copy()
             feature_matrix[~pd.isna(feature_matrix)] = True
             feature_matrix[pd.isna(feature_matrix)] = False
@@ -184,9 +182,9 @@ def sort_oncoprint_labels(data):
             sorted_data.insert(0, "FDR dependency", np.around(fdr, 3))
             sorted_data.insert(0, "p-value dependency", np.around(pvals, 3))
 
-            sorted_data = sorted_data.iloc[sorted_idx]
-
-            store(sorted_data, outpath, labels_df, label_idx=label_idx)
+            outdata = sorted_data.iloc[sorted_idx]
+        outpath = os.path.join(snakemake.output.gene_oncoprint_sortings, f"{label}.tsv")
+        store(outdata, outpath, labels_df, label_idx=label_idx)
 
 
 calls = pd.concat(

--- a/workflow/scripts/oncoprint.py
+++ b/workflow/scripts/oncoprint.py
@@ -77,7 +77,7 @@ def attach_group_annotation(matrix, group_annotation):
     index_cols = matrix.index.names
     return pd.concat(
         [group_annotation.reset_index(drop=True), matrix.reset_index()]
-    ).set_index(index_cols)
+    ).set_index(index_cols).reset_index()
 
 
 def gene_oncoprint(calls, group_annotation):
@@ -100,11 +100,11 @@ def gene_oncoprint(calls, group_annotation):
             # sort by recurrence
             matrix = sort_by_recurrence(matrix, lambda matrix: matrix.isna())
 
-        matrix = attach_group_annotation(matrix, group_annotation)
-        return matrix.reset_index()
+        #matrix = attach_group_annotation(matrix, group_annotation)
+        return matrix
     else:
         cols = ["symbol", "consequence"] + list(snakemake.params.groups)
-        return pd.DataFrame({col: [] for col in cols})
+        return pd.DataFrame({col: [] for col in cols}).set_index(list(snakemake.params.groups))
 
 
 def variant_oncoprint(gene_calls, group_annotation):
@@ -124,7 +124,7 @@ def variant_oncoprint(gene_calls, group_annotation):
 
     matrix = attach_group_annotation(matrix, group_annotation)
 
-    return matrix.reset_index()
+    return matrix
 
 
 calls = pd.concat(
@@ -135,8 +135,10 @@ calls = pd.concat(
 )
 
 group_annotation = load_group_annotation()
-
-gene_oncoprint(calls, group_annotation).to_csv(
+gene_oncoprint = gene_oncoprint(calls, group_annotation)
+gene_oncoprint_main = attach_group_annotation(gene_oncoprint, group_annotation)
+print(gene_oncoprint_main)
+gene_oncoprint.to_csv(
     snakemake.output.gene_oncoprint, sep="\t", index=False
 )
 

--- a/workflow/scripts/oncoprint.py
+++ b/workflow/scripts/oncoprint.py
@@ -149,9 +149,7 @@ def store(data, output, labels_df, label_idx=None):
 
 
 def sort_oncoprint_labels(data):
-    labels_df = pd.read_csv(
-        snakemake.input.group_annotation, index_col="group", sep="\t"
-    ).T
+    labels_df = snakemake.params.labels
     labels = labels_df.index
 
     for label_idx, label in enumerate(labels):


### PR DESCRIPTION
As a new feature reordnering rows in the gene oncoprint based on annotation labels has been added.
Rows are sorted by their statistical dependence on the selected annotation label.
Ordering is determined by the Chi² test which was previously implemented in the dna-seq-benchmark pipline (see [collect-fp-fn.py](https://github.com/snakemake-workflows/dna-seq-benchmark/blob/7a00a2fc7b722a66e6670f220e035ee46133a7bf/workflow/scripts/collect-fp-fn.py#L84)) and served as a template.