### PR TITLE
fix: Fix empty regions bed file

### DIFF
--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -19,7 +19,7 @@ rule freebayes:
         ),
     threads: max(workflow.cores - 1, 1)  # use all available cores -1 (because of the pipe) for calling
     wrapper:
-        "v1.10.0/bio/freebayes"
+        "v1.19.0/bio/freebayes"
 
 
 rule delly:

--- a/workflow/rules/regions.smk
+++ b/workflow/rules/regions.smk
@@ -12,7 +12,7 @@ rule get_target_regions:
     conda:
         "../envs/awk_bedtools.yaml"
     shell:
-        "cat {input} | sort -k1,1 -k2,2n - | mergeBed -i - | awk '{{sub(\"^chr\",\"\", $0); print}}' > {output} 2> {log}"
+        'cat {input} | sort -k1,1 -k2,2n - | mergeBed -i - | awk \'{{sub("^chr","", $0); print}}\' > {output} 2> {log}'
 
 
 rule build_sample_regions:

--- a/workflow/rules/regions.smk
+++ b/workflow/rules/regions.smk
@@ -10,9 +10,9 @@ rule get_target_regions:
     log:
         "logs/regions/target_regions.log",
     conda:
-        "../envs/bedtools.yaml"
+        "../envs/awk_bedtools.yaml"
     shell:
-        "cat {input} | sort -k1,1 -k2,2n - | mergeBed -i - > {output} 2> {log}"
+        "cat {input} | sort -k1,1 -k2,2n - | mergeBed -i - | awk '{{sub(\"^chr\",\"\", $0); print}}' > {output} 2> {log}"
 
 
 rule build_sample_regions:


### PR DESCRIPTION
This PR fixes an issue where freebayes gets an empty bed-file of covered regions.
The issue occurs in case the passed target-regions file contains chromosomal positions where the chromosome is denoted with a `chr`-prefix.
