### PR TITLE
fix: Filter offtarget variants

### DIFF
--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -60,6 +60,10 @@ rule filter_offtarget_variants:
         regions="resources/target_regions/target_regions.bed",
     output:
         "results/candidate-calls/{group}.{caller}.filtered.bcf",
+    params:
+        extra=""
+    log:
+        "logs/filter_offtarget_variants/{group}.{caller}.log"
     wrapper:
         "v1.19.1/bio/bcftools/filter"
 

--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -59,14 +59,14 @@ rule filter_offtarget_variants:
         calls=get_fixed_candidate_calls,
         regions="resources/target_regions/target_regions.bed",
     output:
-        "results/candidate-valls/{group}.{caller}.filtered.bcf",
+        "results/candidate-calls/{group}.{caller}.filtered.bcf",
     wrapper:
         "v1.19.1/bio/bcftools/filter"
 
 
 rule scatter_candidates:
     input:
-        "results/candidate-valls/{group}.{caller}.filtered.bcf"
+        "results/candidate-calls/{group}.{caller}.filtered.bcf"
         if config.get("target_regions", None)
         else get_fixed_candidate_calls,
     output:

--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -61,9 +61,9 @@ rule filter_offtarget_variants:
     output:
         "results/candidate-calls/{group}.{caller}.filtered.bcf",
     params:
-        extra=""
+        extra="",
     log:
-        "logs/filter_offtarget_variants/{group}.{caller}.log"
+        "logs/filter_offtarget_variants/{group}.{caller}.log",
     wrapper:
         "v1.19.1/bio/bcftools/filter"
 

--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -54,9 +54,21 @@ rule fix_delly_calls:
         """bcftools view -e 'INFO/SVTYPE="BND"' {input} -Ob > {output} 2> {log}"""
 
 
+rule filter_offtarget_variants:
+    input:
+        calls=get_fixed_candidate_calls,
+        regions="resources/target_regions/target_regions.bed",
+    output:
+        "results/candidate-valls/{group}.{caller}.filtered.bcf",
+    wrapper:
+        "v1.19.1/bio/bcftools/filter"
+
+
 rule scatter_candidates:
     input:
-        get_fixed_candidate_calls,
+        "results/candidate-valls/{group}.{caller}.filtered.bcf"
+        if config.get("target_regions", None)
+        else get_fixed_candidate_calls,
     output:
         scatter.calling(
             "results/candidate-calls/{{group}}.{{caller}}.{scatteritem}.bcf"


### PR DESCRIPTION
Candidate variants are currently called based on covered and, if provided, the intersection of target regions.
To reduce runtime close regions are getting merged.
As a consequence called variants can originate from off-target regions.
These are now getting eliminated by filtering the candidate calls by target regions if provided.