### PR TITLE
fix: fail for empty target regions

### DIFF
--- a/workflow/rules/regions.smk
+++ b/workflow/rules/regions.smk
@@ -13,8 +13,8 @@ rule get_target_regions:
         "../envs/awk_bedtools.yaml"
     shell:
         """
-        cat {input} | sort -k1,1 -k2,2n - | mergeBed -i - | awk \'{{sub("^chr","", $0); print}}\' > {output} 2> {log} \
-        && [[ -s {output} ]]
+        (cat {input} | sort -k1,1 -k2,2n - | mergeBed -i - | awk \'{{sub("^chr","", $0); print}}\' > {output} \
+        && if [[ ! -s {output} ]]; then >&2 echo 'Empty output: target file appears to be invalid'; exit 1; fi) 2> {log}
         """
 
 

--- a/workflow/rules/regions.smk
+++ b/workflow/rules/regions.smk
@@ -12,7 +12,10 @@ rule get_target_regions:
     conda:
         "../envs/awk_bedtools.yaml"
     shell:
-        'cat {input} | sort -k1,1 -k2,2n - | mergeBed -i - | awk \'{{sub("^chr","", $0); print}}\' > {output} 2> {log}'
+        """
+        cat {input} | sort -k1,1 -k2,2n - | mergeBed -i - | awk \'{{sub("^chr","", $0); print}}\' > {output} 2> {log} \
+        && [[ -s {output} ]]
+        """
 
 
 rule build_sample_regions:


### PR DESCRIPTION
The workflow now fails with a message in case a empty bed file is created from custom target regions.
This might happen in case the custom file is invalid or empty.