### PR TITLE
fix: remove clinical significance duplicate

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -175,7 +175,6 @@ tables:
     # Uncomment and add VEP annotation fields to include (IMPACT, Consequence, Feature, SYMBOL, and HGVSp are always included)
     annotation_fields:
       - EXON
-      - CLIN_SIG
     event_prob: true
     observations: true
   generate_excel: true


### PR DESCRIPTION
Currently the clinical significance is rendered twice in the datavzrd report.
Once as a malformated column named `CLIN_SIG` and another correctly formatted column with identical entries.
To reduce this redundancy the corresponding entry has been removed.