### PR TITLE
feat: Plot simple observations

### DIFF
--- a/workflow/resources/datavzrd/data_short_observations.js
+++ b/workflow/resources/datavzrd/data_short_observations.js
@@ -1,0 +1,25 @@
+function(value) {
+  var regex = /([0-9]+)(N|E|B|P|S|V|n|e|b|p|s|v)/g;
+  var effects = {
+      "N": "None",
+      "E": "Equal",
+      "B": "Barely",
+      "P": "Positive",
+      "S": "Strong",
+      "V": "Very Strong"
+  }
+  var observations = [];
+  while ((result = regex.exec(value)) != null) {
+    effect = effects[result[2].toUpperCase()]
+    var quality = "Low mapping quality";
+    if (result[2] == result[2].toUpperCase()) {
+        quality = "High mapping quality";
+    }
+    observations.push({
+        "effect": effect,
+        "times": parseFloat(result[1]),
+        "quality": quality
+    })
+  }
+  return observations
+}

--- a/workflow/resources/datavzrd/spec_observations.json
+++ b/workflow/resources/datavzrd/spec_observations.json
@@ -1,5 +1,11 @@
 {
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "transform": [
+        {
+          "calculate": "indexof(['Very Strong', 'Strong', 'Positive', 'Barely', 'Equal', 'None'], datum.effect)",
+          "as": "order"
+        }
+      ],
     "mark": "bar",
     "encoding": {
         "column": {
@@ -17,14 +23,15 @@
             "type": "quantitative",
             "title": "Counts"
         },
+        "order": {"field": "order", "type": "ordinal"},
         "color": {
             "field": "effect",
             "type": "nominal",
             "title": "Evidence",
-            "sort": ["None", "Barely", "Positive", "Strong", "Very Strong"],
+            "sort": ["None", "Equal", "Barely", "Positive", "Strong", "Very Strong"],
             "scale": {
-                "domain": ["None", "Barely", "Positive", "Strong", "Very Strong"],
-                "range": ["#999999", "#2ba6cb", "#afdfee", "#ffa3a3", "#ff5555"]
+                "domain": ["None", "Equal", "Barely", "Positive", "Strong", "Very Strong"],
+                "range": ["#999999", "#d3d3d3", "#2ba6cb", "#afdfee", "#ffa3a3", "#ff5555"]
             }
         },
         "tooltip": [ {

--- a/workflow/resources/datavzrd/spec_short_observations.json
+++ b/workflow/resources/datavzrd/spec_short_observations.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+    "transform": [
+        {
+          "calculate": "indexof(['Very Strong', 'Strong', 'Positive', 'Barely', 'Equal', 'None'], datum.effect)",
+          "as": "order"
+        }
+      ],
+    "mark": "bar",
+    "encoding": {
+        "y": {
+            "field": "quality",
+            "type": "ordinal",
+            "title": "Quality"
+        },
+        "x": {
+            "field": "times",
+            "type": "quantitative",
+            "title": "Counts"
+        },
+        "order": {"field": "order", "type": "ordinal"},
+        "color": {
+            "field": "effect",
+            "type": "nominal",
+            "title": "Evidence",
+            "sort": ["None", "Equal", "Barely", "Positive", "Strong", "Very Strong"],
+            "scale": {
+                "domain": ["None", "Equal", "Barely", "Positive", "Strong", "Very Strong"],
+                "range": ["#999999", "#d3d3d3", "#2ba6cb", "#afdfee", "#ffa3a3", "#ff5555"]
+            }
+        },
+        "tooltip": [ {
+            "field": "times",
+            "type": "quantitative",
+            "title": "Counts"
+        } ]
+    }
+}

--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -267,11 +267,17 @@ views:
             display-mode: detail
 
           ?for alias in params.samples.loc[params.samples["group"] == group, "alias"]:
+            '?f"{alias}: short observations"':
+              custom-plot:
+                data: ?read_file(params.data_short_observations)
+                spec: ?read_file(params.spec_short_observations)
+              display-mode: detail
             '?f"{alias}: observations"':
               custom-plot:
                 data: ?read_file(params.data_observations)
                 spec: ?read_file(params.spec_observations)
               display-mode: detail
+
 
 
     ?f"{group}-noncoding":

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -827,7 +827,8 @@ def get_vembrane_config(wildcards, input):
         append_items(events, lambda x: f"INFO['PROB_{x.upper()}']", "prob: {}".format)
     append_format_field("AF", "allele frequency")
     append_format_field("DP", "read depth")
-
+    if config_output.get("short_observations", False):
+        append_format_field("SOBS", "short observations")
     if config_output.get("observations", False):
         append_format_field("OBS", "observations")
     return {"expr": join_items(parts), "header": join_items(header)}

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -103,7 +103,6 @@ def get_heterogeneous_labels():
 
 
 def get_final_output(wildcards):
-
     final_output = expand(
         "results/qc/multiqc/{group}.html",
         group=groups,

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -56,8 +56,14 @@ rule render_datavzrd_config:
         spec_observations=workflow.source_path(
             "../resources/datavzrd/spec_observations.json"
         ),
+        spec_short_observations=workflow.source_path(
+            "../resources/datavzrd/spec_short_observations.json"
+        ),
         data_observations=workflow.source_path(
             "../resources/datavzrd/data_observations.js"
+        ),
+        data_short_observations=workflow.source_path(
+            "../resources/datavzrd/data_short_observations.js"
         ),
         varsome_url=get_varsome_url(),
         samples=samples,
@@ -95,4 +101,4 @@ rule datavzrd_variants_calls:
     log:
         "logs/datavzrd_report/{batch}.{event}.log",
     wrapper:
-        "v1.21.1/utils/datavzrd"
+        "v1.23.3/utils/datavzrd"


### PR DESCRIPTION
In addition to the observation plot in detail view the simple observations will be also plotted as horizontal bar plot.
There have also been some fixes and improvements to the extended observation plot:
- Barplot segments are now descending ordered by evidence starting with `Very strong`.
- the `Barely` segment was missing in previous plots causing a gap without tooltip