### PR TITLE
feat: Set excluded regions for delly

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -73,6 +73,9 @@ calling:
   infer_genotypes: false
   delly:
     activate: true
+    # Set custom excluded regions for delly calling. If commented out predefined templates will be downloaded
+    # from https://github.com/dellytools/delly/tree/main/excludeTemplates
+    # exclude_regions:
   freebayes:
     activate: true
   # See https://varlociraptor.github.io/docs/calling/#generic-variant-calling

--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -28,7 +28,7 @@ rule delly:
         ref_idx=genome_fai,
         alns=lambda w: get_group_bams(w),
         index=lambda w: get_group_bams(w, bai=True),
-        exclude="results/regions/{group}.excluded_regions.bed",
+        exclude=get_delly_excluded_regions(),
     output:
         "results/candidate-calls/{group}.delly.bcf",
     log:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -52,7 +52,7 @@ def get_delly_excluded_regions():
         return custom_excluded_regions
     elif delly_excluded_regions.get((species, build), False):
         return "results/regions/{species_build}.delly_excluded.bed".format(
-            delly_excluded_regions[(species, build)]
+            species_build=delly_excluded_regions[(species, build)]
         )
     else:
         return ""

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -40,6 +40,23 @@ alignmend_ending = "cram" if use_cram else "bam"
 alignmend_index_ending = "crai" if use_cram else "bai"
 alignmend_ending_index_ending = "cram.crai" if use_cram else "bam.bai"
 
+delly_excluded_regions = {
+    ("homo_sapiens", "GRCh38"): "human.hg38",
+    ("homo_sapiens", "GRCh37"): "human.hg19",
+}
+
+
+def get_delly_excluded_regions():
+    custom_excluded_regions = config["calling"]["delly"].get("exclude_regions", "")
+    if custom_excluded_regions:
+        return custom_excluded_regions
+    elif delly_excluded_regions.get((species, build), False):
+        return "results/regions/{species_build}.delly_excluded.bed".format(
+            delly_excluded_regions[(species, build)]
+        )
+    else:
+        return ""
+
 
 def _group_or_sample(row):
     group = row.get("group", None)
@@ -103,7 +120,6 @@ def get_heterogeneous_labels():
 
 
 def get_final_output(wildcards):
-
     final_output = expand(
         "results/qc/multiqc/{group}.html",
         group=groups,

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -46,18 +46,6 @@ delly_excluded_regions = {
 }
 
 
-def get_delly_excluded_regions():
-    custom_excluded_regions = config["calling"]["delly"].get("exclude_regions", "")
-    if custom_excluded_regions:
-        return custom_excluded_regions
-    elif delly_excluded_regions.get((species, build), False):
-        return "results/regions/{species_build}.delly_excluded.bed".format(
-            species_build=delly_excluded_regions[(species, build)]
-        )
-    else:
-        return ""
-
-
 def _group_or_sample(row):
     group = row.get("group", None)
     if pd.isnull(group):
@@ -1001,3 +989,15 @@ def get_oncoprint(oncoprint_type):
             return []
 
     return inner
+
+
+def get_delly_excluded_regions():
+    custom_excluded_regions = config["calling"]["delly"].get("exclude_regions", "")
+    if custom_excluded_regions:
+        return custom_excluded_regions
+    elif delly_excluded_regions.get((species, build), False):
+        return "results/regions/{species_build}.delly_excluded.bed".format(
+            species_build=delly_excluded_regions[(species, build)]
+        )
+    else:
+        return []

--- a/workflow/rules/regions.smk
+++ b/workflow/rules/regions.smk
@@ -89,19 +89,12 @@ rule filter_group_regions:
         "> {output} 2> {log}"
 
 
-rule build_excluded_group_regions:
-    input:
-        target_regions="results/regions/{group}.expanded_regions.filtered.bed",
-        genome_index=genome_fai,
+rule download_delly_excluded_regions:
     output:
-        "results/regions/{group}.excluded_regions.bed",
+        "results/regions/{species}.{build}.delly_excluded.bed",
     params:
-        chroms=config["ref"]["n_chromosomes"],
+        url="https://raw.githubusercontent.com/dellytools/delly/main/excludeTemplates/{species}.{build}.excl.tsv",
     log:
-        "logs/regions/{group}_excluded_regions.log",
-    conda:
-        "../envs/bedtools.yaml"
+        "logs/download_delly_regions.log",
     shell:
-        "(complementBed -i {input.target_regions} -g <(head "
-        "-n {params.chroms} {input.genome_index} | cut "
-        "-f 1,2 | sort -k1,1 -k 2,2n) > {output}) 2> {log}"
+        "curl {params.url} -o {output} &> {log}"

--- a/workflow/rules/regions.smk
+++ b/workflow/rules/regions.smk
@@ -95,6 +95,6 @@ rule download_delly_excluded_regions:
     params:
         url="https://raw.githubusercontent.com/dellytools/delly/main/excludeTemplates/{species}.{build}.excl.tsv",
     log:
-        "logs/download_delly_regions.log",
+        "logs/download_delly_regions/{spiecies}_{build}.log",
     shell:
         "curl {params.url} -o {output} &> {log}"

--- a/workflow/rules/regions.smk
+++ b/workflow/rules/regions.smk
@@ -95,6 +95,6 @@ rule download_delly_excluded_regions:
     params:
         url="https://raw.githubusercontent.com/dellytools/delly/main/excludeTemplates/{species}.{build}.excl.tsv",
     log:
-        "logs/download_delly_regions/{spiecies}_{build}.log",
+        "logs/download_delly_regions/{species}_{build}.log",
     shell:
         "curl {params.url} -o {output} &> {log}"


### PR DESCRIPTION
As the currently implementation of excluding regions for delly may be to strict excluded regions are now handled differently.

Excluded regions can now be defined in the config-file setting `exclude_regions` in the `calling/delly` section.
In case the option is not set a predefined template file will be downloaded from `https://github.com/dellytools/delly/tree/main/excludeTemplates` if existing for the definied species and build.
If neither a custom region file is set nor a predefined template exists delly will be called without excluding regions.