### PR TITLE
fix: update .snakemake-workflow-catalog.yml

### DIFF
--- a/.snakemake-workflow-catalog.yml
+++ b/.snakemake-workflow-catalog.yml
@@ -1,4 +1,7 @@
 usage:
+  mandatory-flags:
+    flags: "--directory .test --configfile .test/config-simple/config.yaml"
+    desc: Use the `.test` directory and the sample configuration
   software-stack-deployment:
     conda: true
   report: true


### PR DESCRIPTION
Add extra flags that enable this workflow to run.

See [snakemake-workflow-catalog](https://snakemake.github.io/snakemake-workflow-catalog/) and click on "standards compliant" at the top for the documentation of this YAML file.