### PR TITLE
feat: handle umis

### DIFF
--- a/config/samples.tsv
+++ b/config/samples.tsv
@@ -1,1 +1,1 @@
-sample_name	alias	group	platform	purity	panel
+sample_name	alias	group	platform	purity	panel	umi_read	umi_read_structure

--- a/config/units.tsv
+++ b/config/units.tsv
@@ -1,1 +1,1 @@
-sample_name	unit_name	fq1	fq2	sra	adapters	umis
+sample_name	unit_name	fq1	fq2	sra	adapters

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -54,6 +54,10 @@ def _group_or_sample(row):
 
 
 samples["group"] = [_group_or_sample(row) for _, row in samples.iterrows()]
+
+if "umi_read" not in samples.columns:
+    samples["umi_read"] = pd.NA
+
 validate(samples, schema="../schemas/samples.schema.yaml")
 
 
@@ -79,9 +83,6 @@ units = (
     .set_index(["sample_name", "unit_name"], drop=False)
     .sort_index()
 )
-
-if "umis" not in units.columns:
-    units["umis"] = pd.NA
 
 validate(units, schema="../schemas/units.schema.yaml")
 
@@ -390,7 +391,7 @@ def get_primer_regions(wc):
 def get_markduplicates_extra(wc):
     c = config["params"]["picard"]["MarkDuplicates"]
 
-    if units.loc[wc.sample]["umis"].isnull().any():
+    if pd.isna(samples.loc[wc.sample]["umi_read"]):
         b = ""
     else:
         b = "--BARCODE_TAG RX"
@@ -783,13 +784,22 @@ def get_tabix_revel_params():
     return f"-f -s 1 -b {column} -e {column}"
 
 
-def get_fastqs(wc):
+def get_untrimmed_fastqs(wc):
+    return units.loc[wc.sample, wc.read]
+
+
+def get_trimmed_fastqs(wc):
     return expand(
         "results/trimmed/{sample}/{unit}_{read}.fastq.gz",
         unit=units.loc[wc.sample, "unit_name"],
         sample=wc.sample,
         read=wc.read,
     )
+
+
+def get_umi_fastq(wc):
+    read = samples.loc[wc.sample, "umi_read"]
+    return "results/untrimmed/{{sample}}_{R}.fastq.gz".format(R=read)
 
 
 def get_vembrane_config(wildcards, input):
@@ -851,6 +861,16 @@ def get_vembrane_config(wildcards, input):
     if config_output.get("observations", False):
         append_format_field("OBS", "observations")
     return {"expr": join_items(parts), "header": join_items(header)}
+
+
+def get_umi_fastq(wildcards):
+    return "results/untrimmed/{S}_{R}.fastq.gz".format(
+        S=wildcards.sample, R=samples.loc[wildcards.sample, "umi_read"]
+    )
+
+
+def get_umi_read_structure(wildcards):
+    return "-r {}".format(samples.loc[wildcards.sample, "umi_read_structure"])
 
 
 def get_sample_alias(wildcards):

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -55,13 +55,13 @@ rule cutadapt_se:
         "v1.12.0/bio/cutadapt/se"
 
 
-rule merge_fastqs:
+rule merge_trimmed_fastqs:
     input:
-        get_fastqs,
+        get_trimmed_fastqs,
     output:
         "results/merged/{sample}_{read}.fastq.gz",
     log:
-        "logs/merge-fastqs/{sample}_{read}.log",
+        "logs/merge-fastqs/trimmed/{sample}_{read}.log",
     wildcard_constraints:
         read="single|R1|R2",
     shell:

--- a/workflow/schemas/samples.schema.yaml
+++ b/workflow/schemas/samples.schema.yaml
@@ -34,6 +34,13 @@ properties:
   primer_panel:
     type: string
     description: ID of primer panel
+  umi_read:
+    type: string
+    enum: ["fq1", "fq2"]
+    description: fq1 or fq2 for read containing umis
+  umi_read_structure:
+    type: string
+    description: read structure defining position of UMIs in reads (see https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures)
 
 
 required:

--- a/workflow/schemas/units.schema.yaml
+++ b/workflow/schemas/units.schema.yaml
@@ -23,9 +23,6 @@ properties:
   adapters:
     type: string
     description: cutadapt adapter trimming settings to use (see https://cutadapt.readthedocs.io)
-  umis:
-    type: string
-    description: path to FASTQ file containing read names and corresponding molecular barcodes (leave emtpy if not exising)
 
 required:
   - sample_name


### PR DESCRIPTION
Until now UMIs where only supported by adding a fastq file containing the UMI of each read.
Often UMIs do not exists as separate fastq records but as part of the read sequences.
To handle UMIs properly information about them is now stored in two additional columns in the samplesheet.
- `umi_read`: Defines whether UMIs are part of records in fq1 or fq2.
- `umi_read_structure`: The template of the read defining the position of UMIs in records (see https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures)

Handling UMIs is optional. In case the `umi_read` column is missing or left empty UMIs will not be annotated for duplicate marking or consensus read calculation. 