### PR TITLE
fix: require bcf index as input to rule filter_offtarget_variants

### DIFF
--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -56,7 +56,8 @@ rule fix_delly_calls:
 
 rule filter_offtarget_variants:
     input:
-        calls=get_fixed_candidate_calls,
+        calls=get_fixed_candidate_calls("bcf"),
+        index=get_fixed_candidate_calls("bcf.csi"),
         regions="resources/target_regions/target_regions.bed",
     output:
         "results/candidate-calls/{group}.{caller}.filtered.bcf",
@@ -72,7 +73,7 @@ rule scatter_candidates:
     input:
         "results/candidate-calls/{group}.{caller}.filtered.bcf"
         if config.get("target_regions", None)
-        else get_fixed_candidate_calls,
+        else get_fixed_candidate_calls("bcf"),
     output:
         scatter.calling(
             "results/candidate-calls/{{group}}.{{caller}}.{scatteritem}.bcf"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -626,11 +626,20 @@ def get_fdr_control_params(wildcards):
     }
 
 
-def get_fixed_candidate_calls(wildcards):
-    if wildcards.caller == "delly":
-        return "results/candidate-calls/{group}.delly.no_bnds.bcf"
-    else:
-        return "results/candidate-calls/{group}.{caller}.bcf"
+def get_fixed_candidate_calls(ext="bcf"):
+    def inner(wildcards):
+        if wildcards.caller == "delly":
+            return expand(
+                "results/candidate-calls/{{group}}.delly.no_bnds.{ext}",
+                ext=ext,
+            )
+        else:
+            return expand(
+                "results/candidate-calls/{{group}}.{{caller}}.{ext}",
+                ext=ext,
+            )
+
+    return inner
 
 
 def get_filter_targets(wildcards, input):


### PR DESCRIPTION
This is the quick fix for #216 . For the more thorough fix in snakemake-wrapper-utils, we should keep that issue open and I'll document what to do over there.