### PR TITLE
fix: fix vembrane aux

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -685,7 +685,7 @@ def get_annotation_filter_expression(wildcards):
 
 def get_annotation_filter_aux(wildcards):
     return [
-        f"--aux {name} {path}"
+        f"--aux {name}={path}"
         for filter in get_annotation_filter_names(wildcards)
         for name, path in get_filter_aux_entries(filter).items()
     ]
@@ -720,7 +720,7 @@ def get_candidate_filter_aux():
         return ""
     else:
         return [
-            f"--aux {name} {path}"
+            f"--aux {name}={path}"
             for name, path in get_filter_aux_entries("candidates").items()
         ]
 


### PR DESCRIPTION
In the previous PR vembrane was updated to v1.0 including a breaking change where the syntax auf aux-arguments was changed from a whitespace to a `=`.
 This was not considered and has been fixed now.