### PR TITLE
feat: Support new varlociraptor 8.0 observations

### DIFF
--- a/workflow/envs/varlociraptor.yaml
+++ b/workflow/envs/varlociraptor.yaml
@@ -3,5 +3,5 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - varlociraptor =7.0
+  - varlociraptor =8.0
   - vega-lite-cli =3.4

--- a/workflow/resources/datavzrd/data_observations.js
+++ b/workflow/resources/datavzrd/data_observations.js
@@ -1,12 +1,16 @@
 function(value) {
-  var regex = /([0-9]+)(A|a|R|r)(N|E|B|P|S|V|n|e|b|p|s|v)(s|p)(\#|\*|\.)(\+|\-|\*)(\>|\<|\*|\!)(\^|\*)(\$|\.)(\*|\.)/g;
+  var regex = /([0-9]+)([A|a|R|r]?[E|B|P|S|V|e|b|p|s|v])(s|p)(\#|\*|\.)(\+|\-|\*)(\>|\<|\*|\!)(\^|\*)(\$|\.)(\*|\.)/g;
   var effects = {
-      "N": "None",
       "E": "Equal",
-      "B": "Barely",
-      "P": "Positive",
-      "S": "Strong",
-      "V": "Very Strong"
+      "AB": "Barely (Alt)",
+      "AP": "Positive (Alt)",
+      "AS": "Strong (Alt)",
+      "AV": "Very Strong (Alt)",
+      "RE": "Equal (Reference)",
+      "RB": "Barely (Reference)",
+      "RP": "Positive (Reference)",
+      "RS": "Strong (Reference)",
+      "RV": "Very Strong (Reference)"
   }
   var observations = [];
   var orientation = {
@@ -15,26 +19,21 @@ function(value) {
       "<": "F2R1",
       "!": "non standard"
   }
-  var allele = {
-    "A": "Alt",
-    "R": "Ref"
-  }
 
   while ((result = regex.exec(value)) != null) {
-    strand = result[6].replace("*", "±")
-    effect = effects[result[3].toUpperCase()]
+    strand = result[5].replace("*", "±")
+    effect = effects[result[2].toUpperCase()]
     var quality = "Low mapping quality";
-    if (result[3] == result[3].toUpperCase()) {
+    if (result[2] == result[2].toUpperCase()) {
         quality = "High mapping quality";
     }
     observations.push({
-        "allele": allele[result[2].toUpperCase()],
         "strand": strand,
-        "strand_orientation": strand + ' ' + orientation[result[7]],
+        "strand_orientation": strand + ' ' + orientation[result[6]],
         "effect": effect,
         "times": parseFloat(result[1]),
         "quality": quality,
-        "orientation": orientation[result[7]]
+        "orientation": orientation[result[6]]
     })
   }
   return observations

--- a/workflow/resources/datavzrd/data_observations.js
+++ b/workflow/resources/datavzrd/data_observations.js
@@ -2,10 +2,10 @@ function(value) {
   var regex = /([0-9]+)([A|a|R|r]?[E|B|P|S|V|e|b|p|s|v])(\.|[0-9]+)(s|p)(\#|\*|\.)(\+|\-|\*)(\>|\<|\*|\!)(\^|\*)(\$|\.)(\*|\.)/g;
   var effects = {
       "E": "Equal",
-      "AB": "Barely (Alt)",
-      "AP": "Positive (Alt)",
-      "AS": "Strong (Alt)",
-      "AV": "Very Strong (Alt)",
+      "AB": "Barely (Alternative)",
+      "AP": "Positive (Alternative)",
+      "AS": "Strong (Alternative)",
+      "AV": "Very Strong (Alternative)",
       "RE": "Equal (Reference)",
       "RB": "Barely (Reference)",
       "RP": "Positive (Reference)",

--- a/workflow/resources/datavzrd/data_observations.js
+++ b/workflow/resources/datavzrd/data_observations.js
@@ -1,5 +1,5 @@
 function(value) {
-  var regex = /([0-9]+)([A|a|R|r]?[E|B|P|S|V|e|b|p|s|v])(s|p)(\#|\*|\.)(\+|\-|\*)(\>|\<|\*|\!)(\^|\*)(\$|\.)(\*|\.)/g;
+  var regex = /([0-9]+)([A|a|R|r]?[E|B|P|S|V|e|b|p|s|v])(\.|[0-9]+)(s|p)(\#|\*|\.)(\+|\-|\*)(\>|\<|\*|\!)(\^|\*)(\$|\.)(\*|\.)/g;
   var effects = {
       "E": "Equal",
       "AB": "Barely (Alt)",
@@ -21,7 +21,8 @@ function(value) {
   }
 
   while ((result = regex.exec(value)) != null) {
-    strand = result[5].replace("*", "±")
+    strand = result[6].replace("*", "±")
+    edit_distance = result[3].replace(".", "None")
     effect = effects[result[2].toUpperCase()]
     var quality = "Low mapping quality";
     if (result[2] == result[2].toUpperCase()) {
@@ -29,11 +30,12 @@ function(value) {
     }
     observations.push({
         "strand": strand,
-        "strand_orientation": strand + ' ' + orientation[result[6]],
+        "strand_orientation": strand + ' ' + orientation[result[7]],
         "effect": effect,
         "times": parseFloat(result[1]),
         "quality": quality,
-        "orientation": orientation[result[6]]
+        "orientation": orientation[result[7]],
+        "edit distance": edit_distance
     })
   }
   return observations

--- a/workflow/resources/datavzrd/data_short_observations.js
+++ b/workflow/resources/datavzrd/data_short_observations.js
@@ -13,12 +13,12 @@ function(value) {
     if (i === 0) {
       allele = "Reference"
     } else {
-      allele = "Alt"
+      allele = "Alternative"
     }
     while ((result = regex.exec(obs[i])) != null) {
       effect = effects[result[2].toUpperCase()]
       if (effect !== "Equal") {
-        effect +=  ' (' + allele + ')'
+        effect +=  ` (${allele})`
       }
       var quality = "Low mapping quality";
       if (result[2] === result[2].toUpperCase()) {

--- a/workflow/resources/datavzrd/data_short_observations.js
+++ b/workflow/resources/datavzrd/data_short_observations.js
@@ -1,30 +1,35 @@
 function(value) {
-  var regex = /([0-9]+)([A|a|R|r]?[E|B|P|S|V|e|b|p|s|v])/g;
+  var regex = /([0-9]+)(E|B|P|S|V|e|b|p|s|v)/g;
   var effects = {
     "E": "Equal",
-    "AB": "Barely (Alt)",
-    "AP": "Positive (Alt)",
-    "AS": "Strong (Alt)",
-    "AV": "Very Strong (Alt)",
-    "RE": "Equal (Reference)",
-    "RB": "Barely (Reference)",
-    "RP": "Positive (Reference)",
-    "RS": "Strong (Reference)",
-    "RV": "Very Strong (Reference)"
-}
-
+    "B": "Barely",
+    "P": "Positive",
+    "S": "Strong",
+    "V": "Very Strong"
+  }
   var observations = [];
-  while ((result = regex.exec(value)) != null) {
-    effect = effects[result[2].toUpperCase()]
-    var quality = "Low mapping quality";
-    if (result[2] == result[2].toUpperCase()) {
-        quality = "High mapping quality";
+  let obs = value.split(",")
+  for (i=0; i<2; i++) {
+    if (i === 0) {
+      allele = "Reference"
+    } else {
+      allele = "Alt"
     }
-    observations.push({
-        "effect": effect,
-        "times": parseFloat(result[1]),
-        "quality": quality
-    })
+    while ((result = regex.exec(obs[i])) != null) {
+      effect = effects[result[2].toUpperCase()]
+      if (effect !== "Equal") {
+        effect +=  ' (' + allele + ')'
+      }
+      var quality = "Low mapping quality";
+      if (result[2] === result[2].toUpperCase()) {
+          quality = "High mapping quality";
+      }
+      observations.push({
+          "effect": effect,
+          "times": parseFloat(result[1]),
+          "quality": quality
+      })
+    }
   }
   return observations
 }

--- a/workflow/resources/datavzrd/data_short_observations.js
+++ b/workflow/resources/datavzrd/data_short_observations.js
@@ -1,27 +1,26 @@
 function(value) {
-  var regex = /([0-9]+)(A|a|R|r)(N|E|B|P|S|V|n|e|b|p|s|v)/g;
+  var regex = /([0-9]+)([A|a|R|r]?[E|B|P|S|V|e|b|p|s|v])/g;
   var effects = {
-      "N": "None",
-      "E": "Equal",
-      "B": "Barely",
-      "P": "Positive",
-      "S": "Strong",
-      "V": "Very Strong"
-  }
-  var allele = {
-    "A": "Alt",
-    "R": "Ref"
-  }
+    "E": "Equal",
+    "AB": "Barely (Alt)",
+    "AP": "Positive (Alt)",
+    "AS": "Strong (Alt)",
+    "AV": "Very Strong (Alt)",
+    "RE": "Equal (Reference)",
+    "RB": "Barely (Reference)",
+    "RP": "Positive (Reference)",
+    "RS": "Strong (Reference)",
+    "RV": "Very Strong (Reference)"
+}
 
   var observations = [];
   while ((result = regex.exec(value)) != null) {
-    effect = effects[result[3].toUpperCase()]
+    effect = effects[result[2].toUpperCase()]
     var quality = "Low mapping quality";
-    if (result[3] == result[3].toUpperCase()) {
+    if (result[2] == result[2].toUpperCase()) {
         quality = "High mapping quality";
     }
     observations.push({
-        "allele": allele[result[2].toUpperCase()],
         "effect": effect,
         "times": parseFloat(result[1]),
         "quality": quality

--- a/workflow/resources/datavzrd/spec_observations.json
+++ b/workflow/resources/datavzrd/spec_observations.json
@@ -54,6 +54,10 @@
             "field": "times",
             "type": "quantitative",
             "title": "Counts"
+        }, {
+            "field": "edit distance",
+            "type": "nominative",
+            "title": "Edit distance"
         }]
     },
     "config": {

--- a/workflow/resources/datavzrd/spec_observations.json
+++ b/workflow/resources/datavzrd/spec_observations.json
@@ -2,7 +2,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "transform": [
         {
-          "calculate": "indexof(['Very Strong', 'Strong', 'Positive', 'Barely', 'Equal', 'None'], datum.effect)",
+          "calculate": "indexof(['Very Strong (Alt)', 'Strong (Alt)', 'Positive (Alt)', 'Barely (Alt)', 'Equal', 'Barely (Reference)', 'Positive (Reference)', 'Strong (Reference)', 'Very Strong (Reference)'], datum.effect)",
           "as": "order"
         }
       ],
@@ -23,18 +23,22 @@
             "type": "quantitative",
             "title": "Counts"
         },
-        "order": {"field": "order", "type": "ordinal"},
+        "order": {"field": "order", "type": "ordinal", "sort": "descending"},
         "color": {
             "field": "effect",
             "type": "nominal",
             "title": "Evidence",
-            "sort": ["None", "Equal", "Barely", "Positive", "Strong", "Very Strong"],
+            "sort": {"field": "order", "order": "descending"},
             "scale": {
-                "domain": ["None", "Equal", "Barely", "Positive", "Strong", "Very Strong"],
-                "range": ["#999999", "#d3d3d3", "#2ba6cb", "#afdfee", "#ffa3a3", "#ff5555"]
+                "domain": ["Very Strong (Alt)", "Strong (Alt)", "Positive (Alt)", "Barely (Alt)", "Equal", "Barely (Reference)", "Positive (Reference)", "Strong (Reference)", "Very Strong (Reference)"],
+                "range": ["#ff5555", "#ff6666", "#ff9999", "#ffcccc", "#999999", "#eaf7fb", "#afdfee", "#6cc5e0", "#2dacd2"]
             }
         },
         "tooltip": [ {
+            "field": "effect",
+            "type": "nominative",
+            "title": "Evidence"
+        }, {
             "field": "strand",
             "type": "nominative",
             "title": "Strand"
@@ -42,6 +46,10 @@
             "field": "orientation",
             "type": "nominal",
             "title": "Orientation"
+        }, {
+            "field": "times",
+            "type": "quantitative",
+            "title": "Counts"
         }, {
             "field": "times",
             "type": "quantitative",

--- a/workflow/resources/datavzrd/spec_observations.json
+++ b/workflow/resources/datavzrd/spec_observations.json
@@ -2,7 +2,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "transform": [
         {
-          "calculate": "indexof(['Very Strong (Alt)', 'Strong (Alt)', 'Positive (Alt)', 'Barely (Alt)', 'Equal', 'Barely (Reference)', 'Positive (Reference)', 'Strong (Reference)', 'Very Strong (Reference)'], datum.effect)",
+          "calculate": "indexof(['Very Strong (Alternative)', 'Strong (Alternative)', 'Positive (Alternative)', 'Barely (Alternative)', 'Equal', 'Barely (Reference)', 'Positive (Reference)', 'Strong (Reference)', 'Very Strong (Reference)'], datum.effect)",
           "as": "order"
         }
       ],
@@ -30,7 +30,7 @@
             "title": "Evidence",
             "sort": {"field": "order", "order": "descending"},
             "scale": {
-                "domain": ["Very Strong (Alt)", "Strong (Alt)", "Positive (Alt)", "Barely (Alt)", "Equal", "Barely (Reference)", "Positive (Reference)", "Strong (Reference)", "Very Strong (Reference)"],
+                "domain": ["Very Strong (Alternative)", "Strong (Alternative)", "Positive (Alternative)", "Barely (Alternative)", "Equal", "Barely (Reference)", "Positive (Reference)", "Strong (Reference)", "Very Strong (Reference)"],
                 "range": ["#ff5555", "#ff6666", "#ff9999", "#ffcccc", "#999999", "#eaf7fb", "#afdfee", "#6cc5e0", "#2dacd2"]
             }
         },

--- a/workflow/resources/datavzrd/spec_short_observations.json
+++ b/workflow/resources/datavzrd/spec_short_observations.json
@@ -2,8 +2,8 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "transform": [
         {
-          "calculate": "indexof(['Very Strong', 'Strong', 'Positive', 'Barely', 'Equal', 'None'], datum.effect)",
-          "as": "order"
+            "calculate": "indexof(['Very Strong (Alt)', 'Strong (Alt)', 'Positive (Alt)', 'Barely (Alt)', 'Equal', 'Barely (Reference)', 'Positive (Reference)', 'Strong (Reference)', 'Very Strong (Reference)'], datum.effect)",
+            "as": "order"
         }
       ],
     "mark": "bar",
@@ -18,18 +18,22 @@
             "type": "quantitative",
             "title": "Counts"
         },
-        "order": {"field": "order", "type": "ordinal"},
+        "order": {"field": "order", "type": "ordinal", "sort": "descending"},
         "color": {
             "field": "effect",
             "type": "nominal",
             "title": "Evidence",
-            "sort": ["None", "Equal", "Barely", "Positive", "Strong", "Very Strong"],
+            "sort": {"field": "order", "order": "descending"},
             "scale": {
-                "domain": ["None", "Equal", "Barely", "Positive", "Strong", "Very Strong"],
-                "range": ["#999999", "#d3d3d3", "#2ba6cb", "#afdfee", "#ffa3a3", "#ff5555"]
+                "domain": ["Very Strong (Alt)", "Strong (Alt)", "Positive (Alt)", "Barely (Alt)", "Equal", "Barely (Reference)", "Positive (Reference)", "Strong (Reference)", "Very Strong (Reference)"],
+                "range": ["#ff5555", "#ff6666", "#ff9999", "#ffcccc", "#999999", "#eaf7fb", "#afdfee", "#6cc5e0", "#2dacd2"]
             }
         },
         "tooltip": [ {
+            "field": "effect",
+            "type": "nominative",
+            "title": "Evidence"
+        }, {
             "field": "times",
             "type": "quantitative",
             "title": "Counts"

--- a/workflow/resources/datavzrd/spec_short_observations.json
+++ b/workflow/resources/datavzrd/spec_short_observations.json
@@ -2,7 +2,7 @@
     "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
     "transform": [
         {
-            "calculate": "indexof(['Very Strong (Alt)', 'Strong (Alt)', 'Positive (Alt)', 'Barely (Alt)', 'Equal', 'Barely (Reference)', 'Positive (Reference)', 'Strong (Reference)', 'Very Strong (Reference)'], datum.effect)",
+            "calculate": "indexof(['Very Strong (Alternative)', 'Strong (Alternative)', 'Positive (Alternative)', 'Barely (Alternative)', 'Equal', 'Barely (Reference)', 'Positive (Reference)', 'Strong (Reference)', 'Very Strong (Reference)'], datum.effect)",
             "as": "order"
         }
       ],
@@ -25,7 +25,7 @@
             "title": "Evidence",
             "sort": {"field": "order", "order": "descending"},
             "scale": {
-                "domain": ["Very Strong (Alt)", "Strong (Alt)", "Positive (Alt)", "Barely (Alt)", "Equal", "Barely (Reference)", "Positive (Reference)", "Strong (Reference)", "Very Strong (Reference)"],
+                "domain": ["Very Strong (Alternative)", "Strong (Alternative)", "Positive (Alternative)", "Barely (Alternative)", "Equal", "Barely (Reference)", "Positive (Reference)", "Strong (Reference)", "Very Strong (Reference)"],
                 "range": ["#ff5555", "#ff6666", "#ff9999", "#ffcccc", "#999999", "#eaf7fb", "#afdfee", "#6cc5e0", "#2dacd2"]
             }
         },

--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -283,13 +283,11 @@ views:
               custom-plot:
                 data: ?read_file(params.data_short_observations)
                 spec: ?read_file(params.spec_short_observations)
-                vega-controls: true
               display-mode: detail
             '?f"{alias}: observations"':
               custom-plot:
                 data: ?read_file(params.data_observations)
                 spec: ?read_file(params.spec_observations)
-                vega-controls: true
               display-mode: detail
 
 

--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -283,11 +283,13 @@ views:
               custom-plot:
                 data: ?read_file(params.data_short_observations)
                 spec: ?read_file(params.spec_short_observations)
+                vega-controls: true
               display-mode: detail
             '?f"{alias}: observations"':
               custom-plot:
                 data: ?read_file(params.data_observations)
                 spec: ?read_file(params.spec_observations)
+                vega-controls: true
               display-mode: detail
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -870,7 +870,9 @@ def get_vembrane_config(wildcards, input):
     append_format_field("AF", "allele frequency")
     append_format_field("DP", "read depth")
     if config_output.get("short_observations", False):
-        append_format_field("SOBS", "short observations")
+        append_format_field("SROBS", "short ref observations")
+        append_format_field("SAOBS", "short alt observations")
+
     if config_output.get("observations", False):
         append_format_field("OBS", "observations")
     return {"expr": join_items(parts), "header": join_items(header)}

--- a/workflow/scripts/split-call-tables.py
+++ b/workflow/scripts/split-call-tables.py
@@ -125,37 +125,16 @@ def cleanup_dataframe(df):
     return df
 
 
-def modify_observations(value, modifier):
-    regex = re.compile("([0-9]+)(E|B|P|S|V|e|b|p|s|v)")
-    observations = ""
-    m = re.findall(regex, value)
-    for count, score in m:
-        if score != "E":
-            observations += count + modifier + score
-        else:
-            observations += count + score
-    return observations
-
-
-def modify_observations(value, modifier):
-    regex = re.compile("([0-9]+)(E|B|P|S|V|e|b|p|s|v)")
-    observations = ""
-    m = re.findall(regex, value)
-    for count, score in m:
-        if score != "E":
-            observations += count + modifier + score
-        else:
-            observations += count + score
-    return observations
-
-
 def join_short_obs(df, samples):
     for sample in samples:
-        df[f"{sample}: short observations"] = ""
-        for allele, abbrev in [("ref", "R"), ("alt", "A")]:
-            df[f"{sample}: short observations"] += df[
-                f"{sample}: short {allele} observations"
-            ].apply(modify_observations, args=(abbrev))
+        sobs_loc = df.columns.get_loc(f"{sample}: observations")
+        df.insert(
+            sobs_loc,
+            f"{sample}: short observations",
+            df[f"{sample}: short ref observations"]
+            + ","
+            + df[f"{sample}: short alt observations"],
+        )
     df = df.drop(
         df.columns[
             df.columns.str.endswith(": short ref observations")

--- a/workflow/scripts/split-call-tables.py
+++ b/workflow/scripts/split-call-tables.py
@@ -19,7 +19,7 @@ def write(df, path):
         if path == snakemake.output.coding:
             # ensure that these columns are kept, even if they contain only NAs in a coding setting
             remaining_columns.extend(["REVEL", "HGVSp", "Symbol"])
-            remaining_columns = [ col for col in df.columns if col in remaining_columns ]
+            remaining_columns = [col for col in df.columns if col in remaining_columns]
         df = df[remaining_columns]
     df.to_csv(path, index=False, sep="\t")
 
@@ -107,12 +107,13 @@ def reorder_prob_cols(df):
         df = df.reindex(columns=updated_columns)
     return df
 
+
 def reorder_vaf_cols(df):
     split_index = df.columns.get_loc("Consequence")
     left_columns = df.iloc[:, 0:split_index].columns
     vaf_columns = df.filter(regex=": allele frequency$").columns
     right_columns = df.iloc[:, split_index:].columns.drop(vaf_columns)
-    reordered_columns =  left_columns.append([vaf_columns, right_columns])
+    reordered_columns = left_columns.append([vaf_columns, right_columns])
     return df[reordered_columns]
 
 
@@ -124,6 +125,46 @@ def cleanup_dataframe(df):
     return df
 
 
+def modify_observations(value, modifier):
+    regex = re.compile("([0-9]+)(E|B|P|S|V|e|b|p|s|v)")
+    observations = ""
+    m = re.findall(regex, value)
+    for count, score in m:
+        if score != "E":
+            observations += count + modifier + score
+        else:
+            observations += count + score
+    return observations
+
+
+def modify_observations(value, modifier):
+    regex = re.compile("([0-9]+)(E|B|P|S|V|e|b|p|s|v)")
+    observations = ""
+    m = re.findall(regex, value)
+    for count, score in m:
+        if score != "E":
+            observations += count + modifier + score
+        else:
+            observations += count + score
+    return observations
+
+
+def join_short_obs(df, samples):
+    for sample in samples:
+        df[f"{sample}: short observations"] = ""
+        for allele, abbrev in [("ref", "R"), ("alt", "A")]:
+            df[f"{sample}: short observations"] += df[
+                f"{sample}: short {allele} observations"
+            ].apply(modify_observations, args=(abbrev))
+    df = df.drop(
+        df.columns[
+            df.columns.str.endswith(": short ref observations")
+            | df.columns.str.endswith(": short alt observations")
+        ],
+        axis=1,
+    )
+    return df
+
 
 calls = pd.read_csv(snakemake.input[0], sep="\t")
 calls["Clinical significance"] = (
@@ -133,6 +174,7 @@ calls["Clinical significance"] = (
     .apply(", ".join)
     .replace("", np.nan)
 )
+
 
 if not calls.empty:
     # these below only work on non empty dataframes
@@ -146,6 +188,8 @@ else:
 calls.set_index("Gene", inplace=True, drop=False)
 samples = get_samples(calls)
 
+if calls.columns.str.endswith(": short ref observations").any():
+    calls = join_short_obs(calls, samples)
 
 coding = ~pd.isna(calls["HGVSp"])
 canonical = calls["Canonical"]
@@ -171,5 +215,4 @@ write(
     coding_calls,
     snakemake.output.coding,
 )
-
 # TODO add possibility to also see non-canonical transcripts (low priority, once everything else works).


### PR DESCRIPTION
This adds support for varlociraptor 8.0 short observations and regular observation fields.
In case of short observations (`SAOBS` and `SROBS`) ref and alt alleles columns are being joined in order to be processable by datavzrd.
For the common `OBS`-field the edit distance is now being considered. 