### PR TITLE
fix: preserve lost variants

### DIFF
--- a/workflow/envs/snpsift.yaml
+++ b/workflow/envs/snpsift.yaml
@@ -2,5 +2,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - snpsift =4.3.1
+  - snpsift =5.1
   - bcftools =1.12


### PR DESCRIPTION
Due to an outdated version of SnpSift it may happen that some variants are getting lost when being annotated.
This issue seems to be fixed in the latest version of SnpSift.