### PR TITLE
fix: use annotated calls for unfiltered callsets

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -174,7 +174,7 @@ def get_control_fdr_input(wildcards):
         by = "ann" if query["local"] else "odds"
         return "results/calls/{{group}}.{{event}}.filtered_{by}.bcf".format(by=by)
     else:
-        return "results/calls/{group}.bcf"
+        return "results/final-calls/{group}.annotated.bcf"
 
 
 def get_recalibrate_quality_input(wildcards, bai=False):


### PR DESCRIPTION
In case of callsets not having any filters `vembrane table` fails as the records of input bcf file have no annotation fields.
To fix this the input for fdr-control needs to be changed to the annotated bcf file.