### PR TITLE
feat!: use lowercase for all header names in report tables

### DIFF
--- a/.test/config-target-regions/config.yaml
+++ b/.test/config-target-regions/config.yaml
@@ -52,7 +52,7 @@ calling:
         desc: Variants with moderate impact
         # Optional column names for sorting
         sort:
-          - Impact
+          - impact
 
 annotations:
   vcfs:

--- a/.test/config-target-regions/config_multiple_beds.yaml
+++ b/.test/config-target-regions/config_multiple_beds.yaml
@@ -54,7 +54,7 @@ calling:
         desc: Variants with moderate impact
         # Optional column names for sorting
         sort:
-          - Impact
+          - impact
 
 annotations:
   vcfs:

--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -39,7 +39,7 @@ datasets:
       headers: ?len(params.group_annotations.columns) + 1
       links:
         gene details:
-          column: Symbol
+          column: symbol
           view: "overview-{value}"
     ?for label in params.labels.index.values:
       ?label:
@@ -54,8 +54,8 @@ datasets:
         links:
           ?for group in params.groups:
             ?group:
-              column: HGVSp
-              table-row: ?f"{group}-coding/HGVSp"
+              column: hgvsp
+              table-row: ?f"{group}-coding/hgvsp"
               optional: true
 
   ?for group, path in zip(params.groups, params.coding_calls):
@@ -97,11 +97,11 @@ views:
                     scale: ordinal
                     color-scheme: category20
           columns:
-            Symbol:
+            symbol:
               link-to-url:
                 ensembl:
                   url: https://www.ensembl.org/Homo_sapiens/Gene/Summary?g={value}
-            Consequence:
+            consequence:
               plot:
                 heatmap:
                   scale: ordinal
@@ -139,9 +139,9 @@ views:
                     scale: ordinal
                     color-scheme: category20
           columns:
-            HGVSp:
+            hgvsp:
               custom: ?varsome_link
-            Consequence:
+            consequence:
               plot:
                 heatmap:
                   scale: ordinal
@@ -153,7 +153,7 @@ views:
                     scale: ordinal
                     color-scheme: paired
                     aux-domain-columns: ?list(params.groups)
-            HGVSg:
+            hgvsg:
               display-mode: hidden
 
   ?for group in params.groups:
@@ -162,16 +162,16 @@ views:
       dataset: ?f"{group}-coding"
       render-table:
         columns:
-          Symbol:
+          symbol:
             link-to-url:
               ensembl:
-                url: https://www.ensembl.org/Homo_sapiens/Transcript/Summary?t={Feature}
+                url: https://www.ensembl.org/Homo_sapiens/Transcript/Summary?t={feature}
           ?if params.varsome_url:
-            HGVSp:
+            hgvsp:
               custom: ?varsome_link
           vartype:
             display-mode: hidden
-          Impact:
+          impact:
             plot:
               heatmap:
                 scale: ordinal
@@ -185,12 +185,12 @@ views:
                   - "#ec5300"
                   - "#ec9b00"
                   - "#ecca00"
-          Consequence:
+          consequence:
             plot:
               heatmap:
                 color-scheme: category20
                 scale: ordinal
-          REVEL:
+          revel:
             optional: true
             plot: 
               heatmap:
@@ -220,11 +220,11 @@ views:
                 range:
                   - white
                   - "#1f77b4"
-          Gene:
+          gene:
             display-mode: hidden
-          Feature:
+          feature:
             display-mode: hidden
-          HGVSg:
+          hgvsg:
             display-mode: detail
           chromosome:
             display-mode: detail
@@ -234,9 +234,9 @@ views:
             display-mode: detail
           alternative allele:
             display-mode: detail
-          Protein position:
+          protein position:
             display-mode: detail
-          Protein alteration (short):
+          protein alteration (short):
             display-mode: detail
           ?for alias in params.samples.loc[params.samples["group"] == group, "alias"]:
             '?f"{alias}: short observations"':
@@ -258,19 +258,19 @@ views:
       dataset: ?f"{group}-noncoding"
       render-table:
         columns:
-          Symbol:
+          symbol:
             optional: true
             link-to-url:
               ensembl:
-                url: https://www.ensembl.org/Homo_sapiens/Transcript/Summary?t={Feature}
-          Consequence:
+                url: https://www.ensembl.org/Homo_sapiens/Transcript/Summary?t={feature}
+          consequence:
             plot:
               heatmap:
                 color-scheme: category20
                 scale: ordinal
           vartype:
             display-mode: hidden
-          Impact:
+          impact:
             plot:
               heatmap:
                 scale: ordinal
@@ -307,11 +307,11 @@ views:
                   - "#1f77b4"
           id:
             display-mode: hidden
-          Gene:
+          gene:
             display-mode: hidden
-          Feature:
+          feature:
             display-mode: hidden
-          HGVSg:
+          hgvsg:
             display-mode: detail
           chromosome:
             display-mode: detail

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -832,17 +832,17 @@ def get_vembrane_config(wildcards, input):
             header.append(header_name)
 
     annotation_fields = [
-        {"name": "Symbol", "expr": "ANN['SYMBOL']"},
+        "SYMBOL",
         "Gene",
         "Feature",
-        {"name": "Impact", "expr": "ANN['IMPACT']"},
+        "IMPACT",
         "HGVSp",
-        {"name": "Protein position", "expr": "ANN['Protein_position'].raw"},
-        {"name": "Protein alteration (short)", "expr": "ANN['Amino_acids']"},
+        {"name": "protein position", "expr": "ANN['Protein_position'].raw"},
+        {"name": "protein alteration (short)", "expr": "ANN['Amino_acids']"},
         "HGVSg",
         "Consequence",
-        {"name": "Canonical", "expr": "ANN['CANONICAL']"},
-        {"name": "Clinical significance", "expr": "ANN['CLIN_SIG']"},
+        "CANONICAL",
+        {"name": "clinical significance", "expr": "ANN['CLIN_SIG']"},
     ]
 
     annotation_fields.extend(
@@ -856,7 +856,7 @@ def get_vembrane_config(wildcards, input):
     if "REVEL" in config["annotations"]["vep"]["plugins"]:
         annotation_fields.append("REVEL")
 
-    append_items(annotation_fields, "ANN['{}']".format)
+    append_items(annotation_fields, "ANN['{}']".format, lambda x: x.lower())
 
     samples = get_group_sample_aliases(wildcards)
 

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -71,7 +71,7 @@ rule get_annotation_gz:
         "logs/get_annotation.log",
     cache: "omit-software"  # save space and time with between workflow caching (see docs)
     wrapper:
-        "v1.5.0/bio/reference/ensembl-annotation"
+        "v1.31.1/bio/reference/ensembl-annotation"
 
 
 rule determine_coding_regions:

--- a/workflow/scripts/split-call-tables.py
+++ b/workflow/scripts/split-call-tables.py
@@ -13,12 +13,12 @@ PROB_EPSILON = 0.01  # columns with all probabilities below will be dropped
 
 
 def write(df, path):
-    df = df.drop(["Canonical"], axis="columns", errors="ignore")
+    df = df.drop(["canonical"], axis="columns", errors="ignore")
     if not df.empty:
         remaining_columns = df.dropna(how="all", axis="columns").columns.tolist()
         if path == snakemake.output.coding:
             # ensure that these columns are kept, even if they contain only NAs in a coding setting
-            remaining_columns.extend(["REVEL", "HGVSp", "Symbol"])
+            remaining_columns.extend(["revel", "hgvsp", "symbol"])
             remaining_columns = [col for col in df.columns if col in remaining_columns]
         df = df[remaining_columns]
     df.to_csv(path, index=False, sep="\t")
@@ -87,7 +87,7 @@ def get_vartype(rec):
 
 def order_impact(df):
     order_impact = ["MODIFIER", "LOW", "MODERATE", "HIGH"]
-    df["Impact"] = pd.Categorical(df["Impact"], order_impact)
+    df["impact"] = pd.Categorical(df["impact"], order_impact)
 
 
 def sort_calls(df):
@@ -109,7 +109,7 @@ def reorder_prob_cols(df):
 
 
 def reorder_vaf_cols(df):
-    split_index = df.columns.get_loc("Consequence")
+    split_index = df.columns.get_loc("consequence")
     left_columns = df.iloc[:, 0:split_index].columns
     vaf_columns = df.filter(regex=": allele frequency$").columns
     right_columns = df.iloc[:, split_index:].columns.drop(vaf_columns)
@@ -146,16 +146,16 @@ def join_short_obs(df, samples):
 
 
 calls = pd.read_csv(snakemake.input[0], sep="\t")
-calls["Clinical significance"] = (
-    calls["Clinical significance"]
+calls["clinical significance"] = (
+    calls["clinical significance"]
     .apply(eval)
     .apply(sorted)
     .apply(", ".join)
     .replace("", np.nan)
 )
 
-calls["Protein alteration (short)"] = (
-    calls["Protein alteration (short)"]
+calls["protein alteration (short)"] = (
+    calls["protein alteration (short)"]
     .apply(eval)
     .apply("/".join)
     .replace("", np.nan)
@@ -171,14 +171,14 @@ else:
     calls["vartype"] = []
 
 
-calls.set_index("Gene", inplace=True, drop=False)
+calls.set_index("gene", inplace=True, drop=False)
 samples = get_samples(calls)
 
 if calls.columns.str.endswith(": short ref observations").any():
     calls = join_short_obs(calls, samples)
 
-coding = ~pd.isna(calls["HGVSp"])
-canonical = calls["Canonical"]
+coding = ~pd.isna(calls["hgvsp"])
+canonical = calls["canonical"]
 
 noncoding_calls = calls[~coding & canonical]
 noncoding_calls = cleanup_dataframe(noncoding_calls)


### PR DESCRIPTION
All header names in the datavzrd report (but also tables) have been set to lowercase making the report more readable but is also more intuitive adding changes to the workflow.