### PR TITLE
feat: add binned vaf column for sorting by allele frequency

### DIFF
--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -66,7 +66,7 @@ rule filter_offtarget_variants:
     log:
         "logs/filter_offtarget_variants/{group}.{caller}.log",
     wrapper:
-        "v1.19.1/bio/bcftools/filter"
+        "v1.32.0/bio/bcftools/filter"
 
 
 rule scatter_candidates:

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -134,7 +134,7 @@ rule get_vep_cache:
         release=config["ref"]["release"],
     log:
         "logs/vep/cache.log",
-    cache: True
+    cache: "omit-software"
     wrapper:
         "v1.31.1/bio/vep/cache"
 

--- a/workflow/scripts/split-call-tables.py
+++ b/workflow/scripts/split-call-tables.py
@@ -147,8 +147,8 @@ def join_short_obs(df, samples):
 def bin_max_vaf(df, samples):
     af_columns = [f"{sample}: allele frequency" for sample in samples]
     max_vaf = df[af_columns].apply("max", axis=1)
-    df["binned_max_vaf"] = pd.cut(max_vaf, [0, 0.33, 0.66, 1.], labels=["low", "medium", "high"])
-    df["binned_max_vaf"] = pd.Categorical(df["binned_max_vaf"], ["low", "medium", "high"])
+    df["binned max vaf"] = pd.cut(max_vaf, [0, 0.33, 0.66, 1.], labels=["low", "medium", "high"])
+    df["binned max vaf"] = pd.Categorical(df["binned max vaf"], ["low", "medium", "high"])
     return df
 
 

--- a/workflow/scripts/split-call-tables.py
+++ b/workflow/scripts/split-call-tables.py
@@ -89,6 +89,10 @@ def order_impact(df):
     order_impact = ["MODIFIER", "LOW", "MODERATE", "HIGH"]
     df["impact"] = pd.Categorical(df["impact"], order_impact)
 
+def order_vaf(df):
+    order_vaf = ["low", "medium", "high"]
+    df["tumor: binned vaf"] = pd.Categorical(df["tumor: binned vaf"], order_vaf)
+
 
 def sort_calls(df):
     df.sort_values(snakemake.params.sorting, ascending=False, inplace=True)
@@ -144,6 +148,11 @@ def join_short_obs(df, samples):
     )
     return df
 
+def bin_vaf(df, samples):
+    for sample in samples:
+        df[f"{sample}: binned vaf"] = pd.cut(df[f"{sample}: allele frequency"], [0, 0.33, 0.66, 1.], labels=["low", "medium", "high"])
+    return df
+
 
 calls = pd.read_csv(snakemake.input[0], sep="\t")
 calls["clinical significance"] = (
@@ -161,21 +170,27 @@ calls["protein alteration (short)"] = (
     .replace("", np.nan)
 )
 
+samples = get_samples(calls)
+
+if calls.columns.str.endswith(": allele frequency").any():
+    calls = bin_vaf(calls, samples)
 
 if not calls.empty:
     # these below only work on non empty dataframes
     calls["vartype"] = calls.apply(get_vartype, axis="columns")
     order_impact(calls)
+    order_vaf(calls)
     sort_calls(calls)
 else:
     calls["vartype"] = []
 
 
 calls.set_index("gene", inplace=True, drop=False)
-samples = get_samples(calls)
 
 if calls.columns.str.endswith(": short ref observations").any():
     calls = join_short_obs(calls, samples)
+
+
 
 coding = ~pd.isna(calls["hgvsp"])
 canonical = calls["canonical"]

--- a/workflow/scripts/split-call-tables.py
+++ b/workflow/scripts/split-call-tables.py
@@ -190,8 +190,6 @@ calls.set_index("gene", inplace=True, drop=False)
 if calls.columns.str.endswith(": short ref observations").any():
     calls = join_short_obs(calls, samples)
 
-
-
 coding = ~pd.isna(calls["hgvsp"])
 canonical = calls["canonical"]
 

--- a/workflow/scripts/split-call-tables.py
+++ b/workflow/scripts/split-call-tables.py
@@ -89,10 +89,6 @@ def order_impact(df):
     order_impact = ["MODIFIER", "LOW", "MODERATE", "HIGH"]
     df["impact"] = pd.Categorical(df["impact"], order_impact)
 
-def order_vaf(df):
-    order_vaf = ["low", "medium", "high"]
-    df["tumor: binned vaf"] = pd.Categorical(df["tumor: binned vaf"], order_vaf)
-
 
 def sort_calls(df):
     df.sort_values(snakemake.params.sorting, ascending=False, inplace=True)
@@ -149,8 +145,10 @@ def join_short_obs(df, samples):
     return df
 
 def bin_vaf(df, samples):
+    order_vaf = ["low", "medium", "high"]
     for sample in samples:
         df[f"{sample}: binned vaf"] = pd.cut(df[f"{sample}: allele frequency"], [0, 0.33, 0.66, 1.], labels=["low", "medium", "high"])
+        df[f"{sample}: binned vaf"] = pd.Categorical(df[f"{sample}: binned vaf"], order_vaf)
     return df
 
 
@@ -179,7 +177,6 @@ if not calls.empty:
     # these below only work on non empty dataframes
     calls["vartype"] = calls.apply(get_vartype, axis="columns")
     order_impact(calls)
-    order_vaf(calls)
     sort_calls(calls)
 else:
     calls["vartype"] = []

--- a/workflow/scripts/split-call-tables.py
+++ b/workflow/scripts/split-call-tables.py
@@ -144,11 +144,11 @@ def join_short_obs(df, samples):
     )
     return df
 
-def bin_vaf(df, samples):
-    order_vaf = ["low", "medium", "high"]
-    for sample in samples:
-        df[f"{sample}: binned vaf"] = pd.cut(df[f"{sample}: allele frequency"], [0, 0.33, 0.66, 1.], labels=["low", "medium", "high"])
-        df[f"{sample}: binned vaf"] = pd.Categorical(df[f"{sample}: binned vaf"], order_vaf)
+def bin_max_vaf(df, samples):
+    af_columns = [f"{sample}: allele frequency" for sample in samples]
+    max_vaf = df[af_columns].apply("max", axis=1)
+    df["binned_max_vaf"] = pd.cut(max_vaf, [0, 0.33, 0.66, 1.], labels=["low", "medium", "high"])
+    df["binned_max_vaf"] = pd.Categorical(df["binned_max_vaf"], ["low", "medium", "high"])
     return df
 
 
@@ -171,7 +171,7 @@ calls["protein alteration (short)"] = (
 samples = get_samples(calls)
 
 if calls.columns.str.endswith(": allele frequency").any():
-    calls = bin_vaf(calls, samples)
+    calls = bin_max_vaf(calls, samples)
 
 if not calls.empty:
     # these below only work on non empty dataframes


### PR DESCRIPTION
As workflows like dna-seq-mtb come with several callsets each being split by low and high allele frequency the final datavzrd report becomes cluttered.
Instead of creating two separate callssets we could create a single one by adding additional binned allele frequency columns(binned into `low`, `medium` and `high`). This allows to sort variants by their AF showing variants with a high frequency on top of the report.

While this PR is just a preparation and the sorting needs to be defined in the callset configuration I would like to discuss if this implementation can be improved. Currently we have a distinct allele frequency for each sample (e.g. tumor and normal) resulting in a corresponding binned AF column.
As we have use predefined callsets in the `dna-seq-mtb` workflow we also need to set the column name for sort in the default-config file which might be something like `tumor: binned vaf`. In this case we would assume that always a sample called `tumor` exist which might not be the case.