### PR TITLE
fix: fix mixed up VEP and VEP-cache versions

### DIFF
--- a/.test/config-giab/config.yaml
+++ b/.test/config-giab/config.yaml
@@ -9,7 +9,7 @@ ref:
   # Ensembl species name
   species: homo_sapiens
   # Ensembl release
-  release: 104
+  release: 109
   # Genome build
   build: GRCh38
   chromosome: 1

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -22,7 +22,7 @@ ref:
   # Ensembl species name
   species: homo_sapiens
   # Ensembl release
-  release: 105
+  release: 109
   # Genome build
   build: GRCh38
   # Optionally, instead of downloading the whole reference from Ensembl via the

--- a/workflow/envs/vep.yaml
+++ b/workflow/envs/vep.yaml
@@ -1,6 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-dependencies:
-  - ensembl-vep =105
-  - bcftools =1.9

--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -17,7 +17,7 @@ rule annotate_candidate_variants:
         "benchmarks/vep/{group}.{caller}.{scatteritem}.annotate_candidates.tsv"
     threads: get_vep_threads()
     wrapper:
-        "v1.22.0/bio/vep/annotate"
+        "v1.31.1/bio/vep/annotate"
 
 
 rule annotate_variants:
@@ -43,7 +43,7 @@ rule annotate_variants:
         "logs/vep/{group}.{scatteritem}.annotate.log",
     threads: get_vep_threads()
     wrapper:
-        "v1.22.0/bio/vep/annotate"
+        "v1.31.1/bio/vep/annotate"
 
 
 # TODO What about multiple ID Fields?

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -136,7 +136,7 @@ rule get_vep_cache:
         "logs/vep/cache.log",
     cache: True
     wrapper:
-        "v1.22.0/bio/vep/cache"
+        "v1.31.1/bio/vep/cache"
 
 
 rule get_vep_plugins:
@@ -147,4 +147,4 @@ rule get_vep_plugins:
     log:
         "logs/vep/plugins.log",
     wrapper:
-        "v1.12.0/bio/vep/plugins"
+        "v1.31.1/bio/vep/plugins"


### PR DESCRIPTION
The current workflow is using snakemake-wrappers for loading VEP=108 while the config-file sets the reference to v105.
To avoid any issues annotating variants I suggest to update the config-file and the snakemake-wrappers to the latest version being v109.