### PR TITLE
fix: observations plots

### DIFF
--- a/workflow/resources/datavzrd/data_observations.js
+++ b/workflow/resources/datavzrd/data_observations.js
@@ -24,9 +24,9 @@ function(value) {
     strand = result[6].replace("*", "±")
     edit_distance = result[3].replace(".", "0")
     effect = effects[result[2].toUpperCase()]
-    var quality = "high";
+    var quality = "low";
     if (result[2] == result[2].toUpperCase()) {
-        quality = "low ";
+        quality = "high";
     }
     observations.push({
         "strand": strand,

--- a/workflow/resources/datavzrd/spec_observations.json
+++ b/workflow/resources/datavzrd/spec_observations.json
@@ -92,10 +92,10 @@
           "Positive (Alt)",
           "Barely (Alt)",
           "Equal",
-          "Barely (Reference)",
-          "Positive (Reference)",
-          "Strong (Reference)",
-          "Very Strong (Reference)"
+          "Barely (Ref)",
+          "Positive (Ref)",
+          "Strong (Ref)",
+          "Very Strong (Ref)"
         ],
         "range": [
           "#ff5555",


### PR DESCRIPTION
In the observation plots reference alleles are currently not being rendered as they the field has been renamed to `Ref` but is still called as `Reference`.
It also looks like high and low mapping qualities were accidentally swapped.  