### PR TITLE
fix: set id optional

### DIFF
--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -317,6 +317,7 @@ views:
           feature:
             display-mode: hidden
           hgvsg:
+            optional: true
             display-mode: detail
           chromosome:
             display-mode: detail

--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -310,6 +310,7 @@ views:
                   - white
                   - "#1f77b4"
           id:
+            optional: true
             display-mode: hidden
           gene:
             display-mode: hidden


### PR DESCRIPTION
In some cases rendering the datavzrd report fails as the input datatable might not contain an `id` column.
This happens when splitting tables into noncoding and coding as empty columns are being dropped.