### PR TITLE
feat!: make annotations for candidate variant filtering configurable

### DIFF
--- a/.test/config-chm-eval/config.yaml
+++ b/.test/config-chm-eval/config.yaml
@@ -125,8 +125,12 @@ annotations:
   dgidb:
     activate: false
   vep:
-    params: --everything
-    plugins: []
+    candidate_calls:
+      params:
+      plugins:
+    final_calls:
+      params: --everything
+      plugins: []
 
 
 params:

--- a/.test/config-chm-eval/config.yaml
+++ b/.test/config-chm-eval/config.yaml
@@ -126,7 +126,7 @@ annotations:
     activate: false
   vep:
     candidate_calls:
-      params:
+      params: ""
       plugins: []
     final_calls:
       params: --everything

--- a/.test/config-chm-eval/config.yaml
+++ b/.test/config-chm-eval/config.yaml
@@ -127,7 +127,7 @@ annotations:
   vep:
     candidate_calls:
       params:
-      plugins:
+      plugins: []
     final_calls:
       params: --everything
       plugins: []

--- a/.test/config-giab/config.yaml
+++ b/.test/config-giab/config.yaml
@@ -120,7 +120,7 @@ annotations:
   vep:
     candidate_calls:
       params:
-      plugins:
+      plugins: []
     final_calls:
       # Consider removing --everything if VEP is slow for you (e.g. for WGS), 
       # and think carefully about which annotations you need.

--- a/.test/config-giab/config.yaml
+++ b/.test/config-giab/config.yaml
@@ -118,10 +118,14 @@ annotations:
     datasources:
       - DrugBank
   vep:
-    # Consider removing --everything if VEP is slow for you (e.g. for WGS), 
-    # and think carefully about which annotations you need.
-    params: ""
-    plugins: []
+    candidate_calls:
+      params:
+      plugins:
+    final_calls:
+      # Consider removing --everything if VEP is slow for you (e.g. for WGS), 
+      # and think carefully about which annotations you need.
+      params: ""
+      plugins: []
 
 params:
   cutadapt: ""

--- a/.test/config-giab/config.yaml
+++ b/.test/config-giab/config.yaml
@@ -119,7 +119,7 @@ annotations:
       - DrugBank
   vep:
     candidate_calls:
-      params:
+      params: ""
       plugins: []
     final_calls:
       # Consider removing --everything if VEP is slow for you (e.g. for WGS), 

--- a/.test/config-no-candidate-filtering/config.yaml
+++ b/.test/config-no-candidate-filtering/config.yaml
@@ -74,7 +74,7 @@ annotations:
   vep:
     candidate_calls:
       params:
-      plugins:
+      plugins: []
     final_calls:
       params: --everything
       plugins:

--- a/.test/config-no-candidate-filtering/config.yaml
+++ b/.test/config-no-candidate-filtering/config.yaml
@@ -73,7 +73,7 @@ annotations:
       - DrugBank
   vep:
     candidate_calls:
-      params:
+      params: ""
       plugins: []
     final_calls:
       params: --everything

--- a/.test/config-no-candidate-filtering/config.yaml
+++ b/.test/config-no-candidate-filtering/config.yaml
@@ -72,11 +72,15 @@ annotations:
     datasources:
       - DrugBank
   vep:
-    params: --everything
-    plugins:
-      # Add any plugin from https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html
-      # Plugin args can be passed as well, e.g. "LoFtool,path/to/custom/scores.txt".
-      - LoFtool
+    candidate_calls:
+      params:
+      plugins:
+    final_calls:
+      params: --everything
+      plugins:
+        # Add any plugin from https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html
+        # Plugin args can be passed as well, e.g. "LoFtool,path/to/custom/scores.txt".
+        - LoFtool
 
 
 params:

--- a/.test/config-simple/config.yaml
+++ b/.test/config-simple/config.yaml
@@ -58,11 +58,15 @@ annotations:
     datasources:
       - DrugBank
   vep:
-    params: --everything
-    plugins:
-      # Add any plugin from https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html
-      # Plugin args can be passed as well, e.g. "LoFtool,path/to/custom/scores.txt".
-      - LoFtool
+    candidate_calls:
+      params: --af_gnomade
+      plugins: 
+    final_calls:
+      params: --everything
+      plugins:
+        # Add any plugin from https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html
+        # Plugin args can be passed as well, e.g. "LoFtool,path/to/custom/scores.txt".
+        - LoFtool
 
 
 params:

--- a/.test/config-simple/config.yaml
+++ b/.test/config-simple/config.yaml
@@ -60,7 +60,7 @@ annotations:
   vep:
     candidate_calls:
       params: --af_gnomade
-      plugins: 
+      plugins: []
     final_calls:
       params: --everything
       plugins:

--- a/.test/config-sra/config.yaml
+++ b/.test/config-sra/config.yaml
@@ -64,7 +64,6 @@ annotations:
       params: --everything
       plugins: []
 
-
 params:
   cutadapt: ""
   picard:

--- a/.test/config-sra/config.yaml
+++ b/.test/config-sra/config.yaml
@@ -59,7 +59,7 @@ annotations:
   vep:
     candidate_calls:
       params:
-      plugins:
+      plugins: []
     final_calls:
       params: --everything
       plugins: []

--- a/.test/config-sra/config.yaml
+++ b/.test/config-sra/config.yaml
@@ -57,8 +57,12 @@ annotations:
   dgidb:
     activate: false
   vep:
-    params: --everything
-    plugins: []
+    candidate_calls:
+      params:
+      plugins:
+    final_calls:
+      params: --everything
+      plugins: []
 
 
 params:

--- a/.test/config-sra/config.yaml
+++ b/.test/config-sra/config.yaml
@@ -58,7 +58,7 @@ annotations:
     activate: false
   vep:
     candidate_calls:
-      params:
+      params: ""
       plugins: []
     final_calls:
       params: --everything

--- a/.test/config-target-regions/config.yaml
+++ b/.test/config-target-regions/config.yaml
@@ -64,7 +64,7 @@ annotations:
       - DrugBank
   vep:
     candidate_calls:
-      params:
+      params: ""
       plugins: []
     final_calls:
       params: --everything

--- a/.test/config-target-regions/config.yaml
+++ b/.test/config-target-regions/config.yaml
@@ -65,7 +65,7 @@ annotations:
   vep:
     candidate_calls:
       params:
-      plugins:
+      plugins: []
     final_calls:
       params: --everything
       plugins:

--- a/.test/config-target-regions/config.yaml
+++ b/.test/config-target-regions/config.yaml
@@ -63,11 +63,15 @@ annotations:
     datasources:
       - DrugBank
   vep:
-    params: --everything
-    plugins:
-      # Add any plugin from https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html
-      # Plugin args can be passed as well, e.g. "LoFtool,path/to/custom/scores.txt".
-      - LoFtool
+    candidate_calls:
+      params:
+      plugins:
+    final_calls:
+      params: --everything
+      plugins:
+        # Add any plugin from https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html
+        # Plugin args can be passed as well, e.g. "LoFtool,path/to/custom/scores.txt".
+        - LoFtool
 
 
 params:

--- a/.test/config-target-regions/config_multiple_beds.yaml
+++ b/.test/config-target-regions/config_multiple_beds.yaml
@@ -65,11 +65,15 @@ annotations:
     datasources:
       - DrugBank
   vep:
-    params: --everything
-    plugins:
-      # Add any plugin from https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html
-      # Plugin args can be passed as well, e.g. "LoFtool,path/to/custom/scores.txt".
-      - LoFtool
+    candidate_calls:
+      params:
+      plugins:
+    final_calls:
+      params: --everything
+      plugins:
+        # Add any plugin from https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html
+        # Plugin args can be passed as well, e.g. "LoFtool,path/to/custom/scores.txt".
+        - LoFtool
 
 
 params:

--- a/.test/config-target-regions/config_multiple_beds.yaml
+++ b/.test/config-target-regions/config_multiple_beds.yaml
@@ -67,7 +67,7 @@ annotations:
   vep:
     candidate_calls:
       params:
-      plugins:
+      plugins: []
     final_calls:
       params: --everything
       plugins:

--- a/.test/config-target-regions/config_multiple_beds.yaml
+++ b/.test/config-target-regions/config_multiple_beds.yaml
@@ -66,7 +66,7 @@ annotations:
       - DrugBank
   vep:
     candidate_calls:
-      params:
+      params: ""
       plugins: []
     final_calls:
       params: --everything

--- a/.test/config_primers/config.yaml
+++ b/.test/config_primers/config.yaml
@@ -63,7 +63,7 @@ annotations:
   vep:
     candidate_calls:
       params:
-      plugins:
+      plugins: []
     final_calls:
       params: --everything
       plugins: []

--- a/.test/config_primers/config.yaml
+++ b/.test/config_primers/config.yaml
@@ -61,8 +61,12 @@ annotations:
     datasources:
       - DrugBank
   vep:
-    params: --everything
-    plugins: []
+    candidate_calls:
+      params:
+      plugins:
+    final_calls:
+      params: --everything
+      plugins: []
 
 
 params:

--- a/.test/config_primers/config.yaml
+++ b/.test/config_primers/config.yaml
@@ -62,7 +62,7 @@ annotations:
       - DrugBank
   vep:
     candidate_calls:
-      params:
+      params: ""
       plugins: []
     final_calls:
       params: --everything

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -165,14 +165,20 @@ annotations:
     datasources:
       - DrugBank
   vep:
+    # Here, you can add annotations that you want to use in filtering out candidate variants
+    # before they are put into varlociraptor for proper variant calling.
+    candidate_calls:
+      params: --af_gnomade
+      plugins:
     # Consider removing --everything if VEP is slow for you (e.g. for WGS),
     # and think carefully about which annotations you need.
-    params: --everything --check_existing
-    plugins:
-      # Add any plugin from https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html
-      # Plugin args can be passed as well, e.g. "LoFtool,path/to/custom/scores.txt".
-      - LoFtool
-      - REVEL
+    final_calls:
+      params: --everything --check_existing
+      plugins:
+        # Add any plugin from https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html
+        # Plugin args can be passed as well, e.g. "LoFtool,path/to/custom/scores.txt".
+        - LoFtool
+        - REVEL
 
 # printing of variants in a table format (might be deprecated soon)
 tables:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -169,7 +169,7 @@ annotations:
     # before they are put into varlociraptor for proper variant calling.
     candidate_calls:
       params: --af_gnomade
-      plugins:
+      plugins: []
     # Consider removing --everything if VEP is slow for you (e.g. for WGS),
     # and think carefully about which annotations you need.
     final_calls:

--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -9,8 +9,10 @@ rule annotate_candidate_variants:
         calls="results/candidate-calls/{group}.{caller}.{scatteritem}.annotated.bcf",
         stats="results/candidate-calls/{group}.{caller}.{scatteritem}.stats.html",
     params:
-        extra="--vcf_info_field ANN",
-        plugins=[],
+        plugins=config["annotations"]["vep"]["candidate_calls"]["plugins"],
+        extra="{} --vcf_info_field ANN ".format(
+            config["annotations"]["vep"]["candidate_calls"]["params"]
+        ),
     log:
         "logs/vep/{group}.{caller}.{scatteritem}.annotate_candidates.log",
     benchmark:
@@ -35,9 +37,9 @@ rule annotate_variants:
     params:
         # Pass a list of plugins to use, see https://www.ensembl.org/info/docs/tools/vep/script/vep_plugins.html
         # Plugin args can be added as well, e.g. via an entry "MyPlugin,1,FOO", see docs.
-        plugins=config["annotations"]["vep"]["plugins"],
+        plugins=config["annotations"]["vep"]["final_calls"]["plugins"],
         extra="{} --vcf_info_field ANN --hgvsg".format(
-            config["annotations"]["vep"]["params"]
+            config["annotations"]["vep"]["final_calls"]["params"]
         ),
     log:
         "logs/vep/{group}.{scatteritem}.annotate.log",

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -603,7 +603,7 @@ def get_vep_threads():
 
 
 def get_plugin_aux(plugin, index=False):
-    if plugin in config["annotations"]["vep"]["plugins"]:
+    if plugin in config["annotations"]["vep"]["final_calls"]["plugins"]:
         if plugin == "REVEL":
             suffix = ".tbi" if index else ""
             return "resources/revel_scores.tsv.gz{suffix}".format(suffix=suffix)
@@ -854,7 +854,7 @@ def get_vembrane_config(wildcards, input):
         ]
     )
 
-    if "REVEL" in config["annotations"]["vep"]["plugins"]:
+    if "REVEL" in config["annotations"]["vep"]["final_calls"]["plugins"]:
         annotation_fields.append("REVEL")
 
     append_items(annotation_fields, "ANN['{}']".format, lambda x: x.lower())

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -255,6 +255,9 @@ properties:
             required:
               - params
               - plugins
+        required:
+          - candidate_calls
+          - final_calls
     required:
       - vep
       - vcfs

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -233,12 +233,22 @@ properties:
               type: string
       vep:
         properties:
-          params:
-            type: string
-          plugins:
-            type: array
-            items:
-              type: string
+          candidate_calls:
+            properties:
+              params:
+                type: string
+              plugins:
+                type: array
+                items:
+                  type: string
+          final_calls:
+            properties:
+              params:
+                type: string
+              plugins:
+                type: array
+                items:
+                  type: string
         required:
           - params
           - plugins

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -241,6 +241,9 @@ properties:
                 type: array
                 items:
                   type: string
+            required:
+              - params
+              - plugins
           final_calls:
             properties:
               params:
@@ -249,9 +252,9 @@ properties:
                 type: array
                 items:
                   type: string
-        required:
-          - params
-          - plugins
+            required:
+              - params
+              - plugins
     required:
       - vep
       - vcfs


### PR DESCRIPTION
We have a use case, where we want to use gnomAD population frequencies of variants to filter out common variants BEFORE running varlociraptor. For this, we need to be able to customize the vep flags (and potentially plugins in the future) used for annotating candidate calls before candidate call filtering. This PR introduces this.