### PR TITLE
feat: Handle trimmed fastqs plus additional fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,14 +53,14 @@ jobs:
         show-disk-usage-on-error: true
 
     - name: Test testcase generation
-      uses: snakemake/snakemake-github-action@v1
+      uses: snakemake/snakemake-github-action@feat/disk_space_on_error
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "results/testcases/a/freebayes/IX:314200 --configfile .test/config-simple/config.yaml --use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache"
 
     - name: Test report
-      uses: snakemake/snakemake-github-action@v1
+      uses: snakemake/snakemake-github-action@feat/disk_space_on_error
       with:
         directory: .test
         snakefile: workflow/Snakefile
@@ -68,7 +68,7 @@ jobs:
 
 
     - name: Test workflow (local FASTQs, target regions)
-      uses: snakemake/snakemake-github-action@v1
+      uses: snakemake/snakemake-github-action@feat/disk_space_on_error
       with:
         directory: .test
         snakefile: workflow/Snakefile
@@ -77,7 +77,7 @@ jobs:
           rm -rf .test/results
 
     - name: Test workflow (local FASTQs, multiple target regions BED files)
-      uses: snakemake/snakemake-github-action@v1
+      uses: snakemake/snakemake-github-action@feat/disk_space_on_error
       with:
         directory: .test
         snakefile: workflow/Snakefile
@@ -86,7 +86,7 @@ jobs:
           rm -rf .test/results
 
     - name: Test workflow (local FASTQs, no candidate filtering)
-      uses: snakemake/snakemake-github-action@v1
+      uses: snakemake/snakemake-github-action@feat/disk_space_on_error
       with:
         directory: .test
         snakefile: workflow/Snakefile
@@ -95,7 +95,7 @@ jobs:
           rm -rf .test/results
 
     - name: Test workflow (local FASTQs primer)
-      uses: snakemake/snakemake-github-action@v1
+      uses: snakemake/snakemake-github-action@feat/disk_space_on_error
       with:
         directory: .test
         snakefile: workflow/Snakefile
@@ -104,7 +104,7 @@ jobs:
           rm -rf .test/results
 
     - name: Test workflow (SRA FASTQs)
-      uses: snakemake/snakemake-github-action@v1
+      uses: snakemake/snakemake-github-action@feat/disk_space_on_error
       with:
         directory: .test
         snakefile: workflow/Snakefile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Lint workflow
-      uses: snakemake/snakemake-github-action@v1.24.0
+      uses: snakemake/snakemake-github-action@v1.25.0
       with:
         directory: .
         snakefile: workflow/Snakefile
@@ -45,7 +45,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Test workflow (local FASTQs)
-      uses: snakemake/snakemake-github-action@feat/disk_space_on_error
+      uses: snakemake/snakemake-github-action@v1
       with:
         directory: .test
         snakefile: workflow/Snakefile
@@ -53,61 +53,67 @@ jobs:
         show-disk-usage-on-error: true
 
     - name: Test testcase generation
-      uses: snakemake/snakemake-github-action@feat/disk_space_on_error
+      uses: snakemake/snakemake-github-action@v1
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "results/testcases/a/freebayes/IX:314200 --configfile .test/config-simple/config.yaml --use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache"
+        show-disk-usage-on-error: true
 
     - name: Test report
-      uses: snakemake/snakemake-github-action@feat/disk_space_on_error
+      uses: snakemake/snakemake-github-action@v1
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-simple/config.yaml --report report.zip"
-
+        show-disk-usage-on-error: true
 
     - name: Test workflow (local FASTQs, target regions)
-      uses: snakemake/snakemake-github-action@feat/disk_space_on_error
+      uses: snakemake/snakemake-github-action@v1
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-target-regions/config.yaml --use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache"
         stagein: |
           rm -rf .test/results
+        show-disk-usage-on-error: true
 
     - name: Test workflow (local FASTQs, multiple target regions BED files)
-      uses: snakemake/snakemake-github-action@feat/disk_space_on_error
+      uses: snakemake/snakemake-github-action@v1
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-target-regions/config_multiple_beds.yaml --use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache"
         stagein: |
           rm -rf .test/results
+        show-disk-usage-on-error: true
 
     - name: Test workflow (local FASTQs, no candidate filtering)
-      uses: snakemake/snakemake-github-action@feat/disk_space_on_error
+      uses: snakemake/snakemake-github-action@v1
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-no-candidate-filtering/config.yaml --dryrun --use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache"
         stagein: |
           rm -rf .test/results
+        show-disk-usage-on-error: true
 
     - name: Test workflow (local FASTQs primer)
-      uses: snakemake/snakemake-github-action@feat/disk_space_on_error
+      uses: snakemake/snakemake-github-action@v1
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config_primers/config.yaml --use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache"
         stagein: |
           rm -rf .test/results
+        show-disk-usage-on-error: true
 
     - name: Test workflow (SRA FASTQs)
-      uses: snakemake/snakemake-github-action@feat/disk_space_on_error
+      uses: snakemake/snakemake-github-action@v1
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-sra/config.yaml --show-failed-logs --use-conda -n -j 10 --conda-cleanup-pkgs cache"
         stagein: |
           rm -rf .test/results
+        show-disk-usage-on-error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--configfile .test/config-simple/config.yaml --use-conda --show-failed-logs -j 10 --conda-cleanup-pkgs cache"
+        show-disk-usage-on-error: true
 
     - name: Test testcase generation
       uses: snakemake/snakemake-github-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Test workflow (local FASTQs)
-      uses: snakemake/snakemake-github-action@v1
+      uses: snakemake/snakemake-github-action@feat/disk_space_on_error
       with:
         directory: .test
         snakefile: workflow/Snakefile

--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -43,7 +43,7 @@ rule annotate_variants:
         "logs/vep/{group}.{scatteritem}.annotate.log",
     threads: get_vep_threads()
     wrapper:
-        "v1.31.1/bio/vep/annotate"
+        "v2.2.1/bio/vep/annotate"
 
 
 # TODO What about multiple ID Fields?

--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -4,8 +4,8 @@ rule freebayes:
         ref_idx=genome_fai,
         regions="results/regions/{group}.expanded_regions.filtered.bed",
         # you can have a list of samples here
-        samples=lambda w: get_group_bams(w),
-        indexes=lambda w: get_group_bams(w, bai=True),
+        alns=lambda w: get_group_bams(w),
+        idxs=lambda w: get_group_bams(w, bai=True),
     output:
         "results/candidate-calls/{group}.freebayes.bcf",
     log:
@@ -19,7 +19,7 @@ rule freebayes:
         ),
     threads: max(workflow.cores - 1, 1)  # use all available cores -1 (because of the pipe) for calling
     wrapper:
-        "v1.19.0/bio/freebayes"
+        "v2.3.0/bio/freebayes"
 
 
 rule delly:


### PR DESCRIPTION
These changes address multiple features/issues.

- freebayes-parallel was failing. This has been fixed by updating to the latest snakemake wrapper
- raw fastq files which already were trimmed on creation were not supported. Now, if no adapter is set in the `units.tsv` trimming with cutadapt will be skipped
- gnomAD allele frequency column was added to the datavzrd report  