### PR TITLE
feat: allow umis in both paired end reads

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -792,7 +792,7 @@ def get_tabix_revel_params():
 
 
 def get_untrimmed_fastqs(wc):
-    return units.loc[wc.sample, wc.read]
+    return units.loc[units.sample_name == wc.sample, wc.read]
 
 
 def get_trimmed_fastqs(wc):
@@ -805,7 +805,7 @@ def get_trimmed_fastqs(wc):
         )
     else:
         fq = "fq1" if wc.read == "R1" or wc.read == "single" else "fq2"
-        return units.loc[wc.sample, fq]
+        return units.loc[units.sample_name == wc.sample, fq]
 
 
 def get_umi_fastq(wc):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -886,6 +886,12 @@ def get_umi_fastq(wildcards):
         return "results/untrimmed/{S}_{R}.fastq.gz".format(
             S=wildcards.sample, R=samples.loc[wildcards.sample, "umi_read"]
         )
+    elif samples.loc[wildcards.sample, "umi_read"] == "both":
+        return expand(
+            "results/untrimmed/{S}_{R}.fastq.gz",
+            S=wildcards.sample,
+            R=["fq1", "fq2"]
+        )
     else:
         return samples.loc[wildcards.sample, "umi_read"]
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -808,11 +808,6 @@ def get_trimmed_fastqs(wc):
         return units.loc[units.sample_name == wc.sample, fq]
 
 
-def get_umi_fastq(wc):
-    read = samples.loc[wc.sample, "umi_read"]
-    return "results/untrimmed/{{sample}}_{R}.fastq.gz".format(R=read)
-
-
 def get_vembrane_config(wildcards, input):
     with open(input.scenario, "r") as scenario_file:
         scenario = yaml.load(scenario_file, Loader=yaml.SafeLoader)

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -41,7 +41,7 @@ rule annotate_umis:
     log:
         "logs/fgbio/annotate_bam/{sample}.log",
     wrapper:
-        "v1.23.4/bio/fgbio/annotatebamwithumis"
+        "v2.3.2/bio/fgbio/annotatebamwithumis"
 
 
 rule mark_duplicates:

--- a/workflow/schemas/samples.schema.yaml
+++ b/workflow/schemas/samples.schema.yaml
@@ -37,7 +37,7 @@ properties:
     description: ID of primer panel
   umi_read:
     type: string
-    pattern: "(^fq[1,2]$)|(.(fq|fastq)(.gz)?)$"
+    pattern: "(^(fq[1,2]|both)$)|(.(fq|fastq)(.gz)?)$"
     description: fq1 or fq2 for read containing umis
   umi_read_structure:
     type: string


### PR DESCRIPTION
Previously, only UMIs in one of the reads could be handled. I encountered a library preparation setup that includes UMIs in both paired end reads. So this pull request generalizes this functionality, and follows up on the respective change in the `fgbio/annotatebamwithumis` wrapper that is already merged:
https://github.com/snakemake/snakemake-wrappers/pull/1726