### PR TITLE
fix: switch mem_gb to mem_mb

### DIFF
--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -37,7 +37,7 @@ rule annotate_umis:
     params:
         extra=get_umi_read_structure,
     resources:
-        mem_mb=10000,
+        mem_mb=lambda wc, input: 4*input.size_mb,
     log:
         "logs/fgbio/annotate_bam/{sample}.log",
     wrapper:

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -37,7 +37,7 @@ rule annotate_umis:
     params:
         extra=get_umi_read_structure,
     resources:
-        mem_mb="10000",
+        mem_mb=10000,
     log:
         "logs/fgbio/annotate_bam/{sample}.log",
     wrapper:

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -37,7 +37,7 @@ rule annotate_umis:
     params:
         extra=get_umi_read_structure,
     resources:
-        mem_mb=lambda wc, input: 4 * input.size_mb,
+        mem_mb=lambda wc, input: 2.5 * input.size_mb,
     log:
         "logs/fgbio/annotate_bam/{sample}.log",
     wrapper:

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -37,7 +37,7 @@ rule annotate_umis:
     params:
         extra=get_umi_read_structure,
     resources:
-        mem_gb="10",
+        mem_mb="10000",
     log:
         "logs/fgbio/annotate_bam/{sample}.log",
     wrapper:

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -37,7 +37,7 @@ rule annotate_umis:
     params:
         extra=get_umi_read_structure,
     resources:
-        mem_mb=lambda wc, input: 4*input.size_mb,
+        mem_mb=lambda wc, input: 4 * input.size_mb,
     log:
         "logs/fgbio/annotate_bam/{sample}.log",
     wrapper:


### PR DESCRIPTION
a `mem_gb` specification plus a `default-resources:` specification of `mem_mb` for a cluster system leads to multiple distinct resource definitions that can get confused -- so we should just stick to the standard `mem_mb` here