### PR TITLE
fix: general fixes and optimizations

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -22,7 +22,7 @@ ref:
   # Ensembl species name
   species: homo_sapiens
   # Ensembl release
-  release: 109
+  release: 110
   # Genome build
   build: GRCh38
   # Optionally, instead of downloading the whole reference from Ensembl via the

--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -19,7 +19,7 @@ rule annotate_candidate_variants:
         "benchmarks/vep/{group}.{caller}.{scatteritem}.annotate_candidates.tsv"
     threads: get_vep_threads()
     wrapper:
-        "v2.3.2/bio/vep/annotate"
+        "v2.4.0-3-g0c8aad0/bio/vep/annotate"
 
 
 rule annotate_variants:
@@ -45,7 +45,7 @@ rule annotate_variants:
         "logs/vep/{group}.{scatteritem}.annotate.log",
     threads: get_vep_threads()
     wrapper:
-        "v2.3.2/bio/vep/annotate"
+        "v2.4.0-3-g0c8aad0/bio/vep/annotate"
 
 
 # TODO What about multiple ID Fields?

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -101,4 +101,4 @@ rule datavzrd_variants_calls:
     log:
         "logs/datavzrd_report/{batch}.{event}.log",
     wrapper:
-        "v2.3.2/utils/datavzrd"
+        "v2.4.0/utils/datavzrd"

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -21,7 +21,7 @@ rule merge_untrimmed_fastqs:
     output:
         temp("results/untrimmed/{sample}_{read}.fastq.gz"),
     log:
-        "logs/merge-fastqs/untrimemd/{sample}_{read}.log",
+        "logs/merge-fastqs/untrimmed/{sample}_{read}.log",
     wildcard_constraints:
         read="fq1|fq2",
     shell:
@@ -37,7 +37,7 @@ rule annotate_umis:
     params:
         extra=get_umi_read_structure,
     resources:
-        mem_gb="10",
+        mem_mb=lambda wc, input: 2.5 * input.size_mb,
     log:
         "logs/fgbio/annotate_bam/{sample}.log",
     wrapper:
@@ -56,8 +56,11 @@ rule mark_duplicates:
         "logs/picard/dedup/{sample}.log",
     params:
         extra=get_markduplicates_extra,
+    resources:
+        #https://broadinstitute.github.io/picard/faq.html
+        mem_mb=3000,
     wrapper:
-        "v2.3.2/bio/picard/markduplicates"
+        "v2.4.0-3-g0c8aad0/bio/picard/markduplicates"
 
 
 rule calc_consensus_reads:
@@ -142,7 +145,7 @@ rule recalibrate_base_qualities:
         "logs/gatk/baserecalibrator/{sample}.log",
     threads: 8
     wrapper:
-        "v2.3.2/bio/gatk/baserecalibratorspark"
+        "v1.25.0/bio/gatk/baserecalibratorspark"
 
 
 ruleorder: apply_bqsr > bam_index

--- a/workflow/rules/primers.smk
+++ b/workflow/rules/primers.smk
@@ -3,7 +3,7 @@ rule assign_primers:
         bam=get_trimming_input,
         primers=get_primer_regions,
     output:
-        assigned="results/primers/{sample}.assigned.bam",
+        assigned=temp("results/primers/{sample}.assigned.bam"),
         metric="results/primers/{sample}.metric.bam",
     conda:
         "../envs/fgbio.yaml"
@@ -17,8 +17,8 @@ rule filter_primerless_reads:
     input:
         "results/primers/{sample}.assigned.bam",
     output:
-        primers="results/primers/{sample}.primers.bam",
-        primerless="results/primers/{sample}.primerless.bam",
+        primers=temp("results/primers/{sample}.primers.bam"),
+        primerless=temp("results/primers/{sample}.primerless.bam"),
     conda:
         "../envs/filter_reads.yaml"
     log:
@@ -32,7 +32,7 @@ rule trim_primers:
         bam="results/primers/{sample}.primers.bam",
         primers=get_primer_regions,
     output:
-        trimmed="results/trimmed/{sample}.trimmed.bam",
+        trimmed=temp("results/trimmed/{sample}.trimmed.bam"),
     params:
         sort_order="Coordinate",
         single_primer=get_single_primer_flag,

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -56,7 +56,7 @@ rule get_known_variants:
         chromosome=config["ref"].get("chromosome"),
     cache: "omit-software"
     wrapper:
-        "v2.3.2/bio/reference/ensembl-variation"
+        "v2.4.0-6-g702a85b/bio/reference/ensembl-variation"
 
 
 rule get_annotation_gz:

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -26,8 +26,8 @@ rule cutadapt_pe:
     input:
         get_cutadapt_input,
     output:
-        fastq1="results/trimmed/{sample}/{unit}_R1.fastq.gz",
-        fastq2="results/trimmed/{sample}/{unit}_R2.fastq.gz",
+        fastq1=temp("results/trimmed/{sample}/{unit}_R1.fastq.gz"),
+        fastq2=temp("results/trimmed/{sample}/{unit}_R2.fastq.gz"),
         qc="results/trimmed/{sample}/{unit}.paired.qc.txt",
     log:
         "logs/cutadapt/{sample}-{unit}.log",
@@ -43,7 +43,7 @@ rule cutadapt_se:
     input:
         get_cutadapt_input,
     output:
-        fastq="results/trimmed/{sample}/{unit}.single.fastq.gz",
+        fastq=temp("results/trimmed/{sample}/{unit}.single.fastq.gz"),
         qc="results/trimmed/{sample}/{unit}.single.qc.txt",
     log:
         "logs/cutadapt/{sample}-{unit}.se.log",


### PR DESCRIPTION
Since updating all integrated wrappers the workflow fails at certain points.
Besides we write a lot of intermediate fastq and bam files without deleting them. For large samples this might end up in over a hundred gigabytes of additional disk storage. I therefore marked all of these intermediate results as temporary only keeping merged fastqs and recalibrated bam files.

List of changes:
- updated datavzrd to latest version
- updated `vep annotate` wrapper as it still used `vep v109` while `vep cache` already already used `v110`
- set memory for picard to 3gb
  - the faq recommand to use 1GB per 250.000 reads in memory with length of 100bp. Per default there are 500.000reads in memory and I assumed a read length of 150bp ending up with 3GB. In addition broad uses internally at least 2GB (https://broadinstitute.github.io/picard/faq.html)
- downgrade `gatk baserecalibrator` wrapper as baserecalibration fails.
  - the error seems to be caused by gatk as the error says that the known variants gtf file can not found which is previously copied to a temporary directory by the tool it self. Considering the documentation there has nothing changed how gatk is run so this seems to be a bug.
- updated `ensembl-variation` wrapper as the previous version failed due to downloaded index files
 