### PR TITLE
fix: sample has umis

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -392,9 +392,9 @@ def get_markduplicates_extra(wc):
     c = config["params"]["picard"]["MarkDuplicates"]
 
     if sample_has_umis(wc.sample):
-        b = ""
-    else:
         b = "--BARCODE_TAG RX"
+    else:
+        b = ""
 
     if is_activated("calc_consensus_reads"):
         d = "--TAG_DUPLICATE_SET_MEMBERS true"
@@ -898,7 +898,7 @@ def get_umi_fastq(wildcards):
 
 
 def sample_has_umis(sample):
-    return pd.isna(samples.loc[sample, "umi_read"])
+    return pd.notna(samples.loc[sample, "umi_read"])
 
 
 def get_umi_read_structure(wildcards):

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -46,9 +46,9 @@ rule annotate_umis:
 
 rule mark_duplicates:
     input:
-        bams=lambda wc: "results/mapped/{sample}.bam"
+        bams=lambda wc: "results/mapped/{sample}.annotated.bam"
         if sample_has_umis(wc.sample)
-        else "results/mapped/{sample}.annotated.bam",
+        else "results/mapped/{sample}.bam",
     output:
         bam=temp("results/dedup/{sample}.bam"),
         metrics="results/qc/dedup/{sample}.metrics.txt",


### PR DESCRIPTION
Not really a fix but a semantical correction. The function `sample_has_umis` returns `false` if a sample contains umis.
As this implementation was consistently confused the workflow ran correctly.
Still, to prevent any mistakes in the future it should be changed.