### PR TITLE
fix: update fastqc wrapper to `v1.10.0` to include memory parsing fix

### DIFF
--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -7,7 +7,7 @@ rule fastqc:
     log:
         "logs/fastqc/{sample}/{unit}.{fq}.log",
     wrapper:
-        "v2.3.2/bio/fastqc"
+        "v2.10.0/bio/fastqc"
 
 
 rule samtools_idxstats:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -48,4 +48,4 @@ rule multiqc:
     log:
         "logs/multiqc/{group}.log",
     wrapper:
-        "v2.7.0/bio/multiqc"
+        "v2.10.0/bio/multiqc"


### PR DESCRIPTION
The memory parsing fix for the wrapper was introduced in `snakemake-wrapper-utils` here:
https://github.com/snakemake/snakemake-wrapper-utils/pull/34