### PR TITLE
fix: unique values when extracting samples column for repeated samples (in multiple groups)

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -354,7 +354,7 @@ def get_primer_bed(wc):
 
 
 def extract_unique_sample_column_value(sample, col_name):
-    result = samples.loc[samples["sample"] == sample, col_name].drop_duplicates()
+    result = samples.loc[samples["sample_name"] == sample, col_name].drop_duplicates()
     if type(result) is not str:
         if len(result) > 1:
             ValueError(

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -525,8 +525,6 @@ def is_activated(xpath):
 def get_read_group(wildcards):
     """Denote sample name and platform in read group."""
     platform = extract_unique_sample_column_value(wildcards.sample, "platform")
-    if not isinstance(platform, str):
-        platform = platform.drop_duplicates().iloc[0]
     return r"-R '@RG\tID:{sample}\tSM:{sample}\tPL:{platform}'".format(
         sample=wildcards.sample, platform=platform
     )

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -353,9 +353,26 @@ def get_primer_bed(wc):
             return "results/primers/uniform_primers.bed"
 
 
+def extract_unique_sample_column_value(sample, col_name):
+    result = samples.loc[samples["sample"] == sample, col_name].drop_duplicates()
+    if type(result) is not str:
+        if len(result) > 1:
+            ValueError(
+                "If a sample is specified multiple times in a samples.tsv"
+                "sheet, all columns except 'group' must contain identical"
+                "entries across the occurrences (rows).\n"
+                f"Here we have sample '{sample}' with multiple entries for"
+                f"the '{col_name}' column, namely:\n"
+                f"{result}\n"
+            )
+        else:
+            result = result.squeeze()
+    else return result
+
+
 def get_sample_primer_fastas(sample):
     if isinstance(primer_panels, pd.DataFrame):
-        panel = samples.loc[sample, "panel"]
+        panel = extract_unique_sample_column_value(sample, "panel")
         if not pd.isna(primer_panels.loc[panel, "fa2"]):
             return [
                 primer_panels.loc[panel, "fa1"],
@@ -394,9 +411,8 @@ def input_is_fasta(primers):
 
 def get_primer_regions(wc):
     if isinstance(primer_panels, pd.DataFrame):
-        return "results/primers/{}_primer_regions.tsv".format(
-            samples.loc[wc.sample, "panel"]
-        )
+        panel = extract_unique_sample_column_value(wc.sample, "panel")
+        return f"results/primers/{panel}_primer_regions.tsv"
     return "results/primers/uniform_primer_regions.tsv"
 
 
@@ -507,7 +523,7 @@ def is_activated(xpath):
 
 def get_read_group(wildcards):
     """Denote sample name and platform in read group."""
-    platform = samples.loc[wildcards.sample, "platform"]
+    platform = extract_unique_sample_column_value(wildcards.sample, "platform")
     if not isinstance(platform, str):
         platform = platform.drop_duplicates().iloc[0]
     return r"-R '@RG\tID:{sample}\tSM:{sample}\tPL:{platform}'".format(
@@ -897,28 +913,27 @@ def get_vembrane_config(wildcards, input):
 
 
 def get_umi_fastq(wildcards):
-    if samples.loc[wildcards.sample, "umi_read"] in ["fq1", "fq2"]:
+    umi_read = extract_unique_sample_column_value(wildcards.sample, "umi_read")
+    if umi_read in ["fq1", "fq2"]:
         return "results/untrimmed/{S}_{R}.fastq.gz".format(
-            S=wildcards.sample, R=samples.loc[wildcards.sample, "umi_read"]
+            S=wildcards.sample, R=umi_read
         )
-    elif samples.loc[wildcards.sample, "umi_read"] == "both":
+    elif umi_read == "both":
         return expand(
             "results/untrimmed/{S}_{R}.fastq.gz", S=wildcards.sample, R=["fq1", "fq2"]
         )
     else:
-        return samples.loc[wildcards.sample, "umi_read"]
+        return umi_read
 
 
 def sample_has_umis(sample):
-    return pd.notna(samples.loc[sample, "umi_read"])
+    return pd.notna(
+        extract_unique_sample_column_value(sample, "umi_read")
+    )
 
 
 def get_umi_read_structure(wildcards):
-    return "-r {}".format(samples.loc[wildcards.sample, "umi_read_structure"])
-
-
-def get_sample_alias(wildcards):
-    return samples.loc[wildcards.sample, "alias"]
+    return "-r {}".format(extract_unique_sample_column_value(wildcards.sample, "umi_read_structure"))
 
 
 def get_dgidb_datasources():

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -367,8 +367,7 @@ def extract_unique_sample_column_value(sample, col_name):
             )
         else:
             result = result.squeeze()
-    else:
-        return result
+    return result
 
 
 def get_sample_primer_fastas(sample):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -367,7 +367,8 @@ def extract_unique_sample_column_value(sample, col_name):
             )
         else:
             result = result.squeeze()
-    else return result
+    else:
+        return result
 
 
 def get_sample_primer_fastas(sample):
@@ -927,13 +928,13 @@ def get_umi_fastq(wildcards):
 
 
 def sample_has_umis(sample):
-    return pd.notna(
-        extract_unique_sample_column_value(sample, "umi_read")
-    )
+    return pd.notna(extract_unique_sample_column_value(sample, "umi_read"))
 
 
 def get_umi_read_structure(wildcards):
-    return "-r {}".format(extract_unique_sample_column_value(wildcards.sample, "umi_read_structure"))
+    return "-r {}".format(
+        extract_unique_sample_column_value(wildcards.sample, "umi_read_structure")
+    )
 
 
 def get_dgidb_datasources():


### PR DESCRIPTION
Also provide helpful error if the extracted series contains multiple distinct values.

Previously, these did not get triggered by our tests, because we apparently don't yet test the combination of having UMIs or primers specified AND having a sample repeated. So I'll also try extending one of the simpler tests accordingly on this PR.