### PR TITLE
feat: colored tick plots in datavzrd report

### DIFF
--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -240,11 +240,12 @@ views:
                   - "regex('.+: allele frequency')"
                 color:
                   scale: "linear"
-                  domain: [0.0, 0.05, 1.0]
+                  domain: [0.0, 0.05, 0.0500000001, 1.0]
                   range:
-                    - white
-                    - "#d3e9f8"
-                    - "#1f77b4"
+                  - "#ffd6b3"
+                  - "#ff7f0e"
+                  - "#a8d2f0"
+                  - "#1f77b4"
           "regex('.+: read depth')":
             plot:
               ticks:
@@ -353,11 +354,12 @@ views:
                   - "regex('.+: allele frequency')"
                 color:
                   scale: "linear"
-                  domain: [0.0, 0.05, 1.0]
+                  domain: [0.0, 0.05, 0.0500000001, 1.0]
                   range:
-                    - white
-                    - "#d3e9f8"
-                    - "#1f77b4"
+                  - "#ffd6b3"
+                  - "#ff7f0e"
+                  - "#a8d2f0"
+                  - "#1f77b4"
           "regex('.+: read depth')":
             plot:
               ticks:

--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -233,13 +233,18 @@ views:
                   - "#ff5555"
           "regex('.+: allele frequency')":
             plot:
-              heatmap:
+              ticks:
                 scale: "linear"
-                domain: [0.0, 0.05, 1.0]
-                range:
-                  - white
-                  - "#d3e9f8"
-                  - "#1f77b4"
+                domain: [0.0, 1.0]
+                aux-domain-columns:
+                  - "regex('.+: allele frequency')"
+                color:
+                  scale: "linear"
+                  domain: [0.0, 0.05, 1.0]
+                  range:
+                    - white
+                    - "#d3e9f8"
+                    - "#1f77b4"
           "regex('.+: read depth')":
             plot:
               ticks:
@@ -341,13 +346,18 @@ views:
                   - "#ecca00"
           "regex('.+: allele frequency')":
             plot:
-              heatmap:
+              ticks:
                 scale: "linear"
-                domain: [0.0, 0.05, 1.0]
-                range:
-                  - white
-                  - "#d3e9f8"
-                  - "#1f77b4"
+                domain: [0.0, 1.0]
+                aux-domain-columns:
+                  - "regex('.+: allele frequency')"
+                color:
+                  scale: "linear"
+                  domain: [0.0, 0.05, 1.0]
+                  range:
+                    - white
+                    - "#d3e9f8"
+                    - "#1f77b4"
           "regex('.+: read depth')":
             plot:
               ticks:

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -101,7 +101,7 @@ rule datavzrd_variants_calls:
     log:
         "logs/datavzrd_report/{batch}.{event}.log",
     wrapper:
-        "v2.10.0/utils/datavzrd"
+        "v3.0.2/utils/datavzrd"
 
 
 rule bedtools_merge:
@@ -167,4 +167,4 @@ rule datavzrd_coverage:
     log:
         "logs/datavzrd_report/{group}.coverage.log",
     wrapper:
-        "v2.10.0/utils/datavzrd"
+        "v3.0.2/utils/datavzrd"


### PR DESCRIPTION
After tick plots have been replaced by heatmaps in a previous PR these are once again replaced by new tick plots with color mapping introduced in the latest datavzrd version.