### PR TITLE
feat: render canonical transcript source

### DIFF
--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -58,6 +58,19 @@ __definitions__:
         return `https://${{build}}${{url_suffix}}${{hgvsg}}`
       }}
     """
+  - |
+    protein_id = f"""
+      function(row) {{
+        let protein_id = row.hgvsp.split(':')[0]
+        return protein_id
+      }}
+    """
+  - |
+    empty_content = f"""
+      function(row) {{
+        return ""
+      }}
+    """
 
 datasets:
   ?if input.variant_oncoprints:
@@ -290,6 +303,28 @@ views:
             display-mode: detail
           protein alteration (short):
             display-mode: detail
+          canonical:
+            optional: true
+            display-mode: detail
+            plot:
+              heatmap:
+                scale: "ordinal"
+                domain: ["", "True"]
+                range:
+                  - white
+                  - black
+                custom-content: ?empty_content
+          mane_plus_clinical:
+            optional: true
+            display-mode: detail
+            plot:
+              heatmap:
+                scale: "ordinal"
+                domain: ["", "True"]
+                range:
+                  - white
+                  - black
+                custom-content: ?empty_content
           ?for alias in params.samples.loc[params.samples["group"] == group, "alias"]:
             '?f"{alias}: short observations"':
               optional: true
@@ -310,6 +345,10 @@ views:
           query_genomenexus:
             value: ?genomenexus_link
             display-mode: hidden
+          ensembl_protein_id:
+            value: ?protein_id
+            display-mode: detail
+
 
 
 
@@ -404,6 +443,28 @@ views:
             display-mode: detail
           alternative allele:
             display-mode: detail
+          canonical:
+            optional: true
+            display-mode: detail
+            plot:
+              heatmap:
+                scale: "ordinal"
+                domain: ["", "True"]
+                range:
+                  - white
+                  - black
+                custom-content: ?empty_content
+          mane_plus_clinical:
+            optional: true
+            display-mode: detail
+            plot:
+              heatmap:
+                scale: "ordinal"
+                domain: ["", "True"]
+                range:
+                  - white
+                  - black
+                custom-content: ?empty_content
           ?for alias in params.samples.loc[params.samples["group"] == group, "alias"]:
             '?f"{alias}: short observations"':
               optional: true

--- a/workflow/scripts/split-call-tables.py
+++ b/workflow/scripts/split-call-tables.py
@@ -13,8 +13,7 @@ PROB_EPSILON = 0.01  # columns with all probabilities below will be dropped
 
 
 def write(df, path):
-    df = df.drop(["mane_plus_clinical"], axis="columns", errors="ignore")
-    df = df.drop(["canonical"], axis="columns", errors="ignore")
+    df["mane_plus_clinical"][df["mane_plus_clinical"].notna()] = True
     if not df.empty:
         remaining_columns = df.dropna(how="all", axis="columns").columns.tolist()
         if path == snakemake.output.coding:


### PR DESCRIPTION
In some rare cases multiple transcripts for the same variant show up in the datavzrd report.
This happens in case the `canonical` and `mane_plus_clinical` fields state different transcripts as canonical.
As we can not identify the correct one we added both entries to the datavzrd report in the detail view showing black cells for supporting transcripts.
Additionally, a column for Enseml protein ID has been added.