### PR TITLE
feat: reduce fgbio memory usage

### DIFF
--- a/workflow/envs/fgbio.yaml
+++ b/workflow/envs/fgbio.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - fgbio =2.2
+  - fgbio-minimal =2.2

--- a/workflow/envs/fgbio.yaml
+++ b/workflow/envs/fgbio.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - fgbio =1.4
+  - fgbio =2.2

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -589,6 +589,18 @@ def get_read_group(wildcards):
     )
 
 
+def get_map_reads_sorting_params(wildcards, order_param=False):
+    match (sample_has_umis(wildcards.sample), order_param):
+        case (True, True):
+            return "queryname"
+        case (True, False):
+            return "fgbio"
+        case (False, True):
+            return "coordinate"
+        case (False, False):
+            return "samtools"
+
+
 def get_mutational_burden_targets():
     mutational_burden_targets = []
     if is_activated("mutational_burden"):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1113,8 +1113,8 @@ def sample_has_umis(sample):
     return pd.notna(extract_unique_sample_column_value(sample, "umi_read"))
 
 
-def get_umi_read_structure(wildcards):
-    return "-s true -r {}".format(
+def get_annotate_umis_params(wildcards):
+    return "--sorted=true -r {}".format(
         extract_unique_sample_column_value(wildcards.sample, "umi_read_structure")
     )
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1091,7 +1091,7 @@ def get_umi_fastq(wildcards):
         return expand(
             "results/untrimmed/{S}_{R}.sorted.fastq.gz",
             S=wildcards.sample,
-            R=["fq1", "fq2"]
+            R=["fq1", "fq2"],
         )
     else:
         return umi_read

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -396,7 +396,7 @@ def get_sample_datatype(sample):
 def get_markduplicates_input(wildcards):
     aligner = "star" if get_sample_datatype(wildcards.sample) == "rna" else "bwa"
     if sample_has_umis(wildcards.sample):
-        return "results/mapped/{aligner}/{{sample}}.annotated.bam".format(
+        return "results/mapped/{aligner}/{{sample}}.annotated.sorted.bam".format(
             aligner=aligner
         )
     else:
@@ -1084,12 +1084,12 @@ def get_vembrane_config(wildcards, input):
 def get_umi_fastq(wildcards):
     umi_read = extract_unique_sample_column_value(wildcards.sample, "umi_read")
     if umi_read in ["fq1", "fq2"]:
-        return "results/untrimmed/{S}_{R}.fastq.gz".format(
+        return "results/untrimmed/{S}_{R}.sorted.fastq.gz".format(
             S=wildcards.sample, R=umi_read
         )
     elif umi_read == "both":
         return expand(
-            "results/untrimmed/{S}_{R}.fastq.gz", S=wildcards.sample, R=["fq1", "fq2"]
+            "results/untrimmed/{S}_{R}.sorted.fastq.gz", S=wildcards.sample, R=["fq1", "fq2"]
         )
     else:
         return umi_read
@@ -1100,7 +1100,7 @@ def sample_has_umis(sample):
 
 
 def get_umi_read_structure(wildcards):
-    return "-r {}".format(
+    return "-s true -r {}".format(
         extract_unique_sample_column_value(wildcards.sample, "umi_read_structure")
     )
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -589,8 +589,8 @@ def get_read_group(wildcards):
     )
 
 
-def get_map_reads_sorting_params(wildcards, order_param=False):
-    match (sample_has_umis(wildcards.sample), order_param):
+def get_map_reads_sorting_params(wildcards, ordering=False):
+    match (sample_has_umis(wildcards.sample), ordering):
         case (True, True):
             return "queryname"
         case (True, False):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -396,7 +396,7 @@ def get_sample_datatype(sample):
 def get_markduplicates_input(wildcards):
     aligner = "star" if get_sample_datatype(wildcards.sample) == "rna" else "bwa"
     if sample_has_umis(wildcards.sample):
-        return "results/mapped/{aligner}/{{sample}}.annotated.sorted.bam".format(
+        return "results/mapped/{aligner}/{{sample}}.annotated.bam".format(
             aligner=aligner
         )
     else:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1089,7 +1089,9 @@ def get_umi_fastq(wildcards):
         )
     elif umi_read == "both":
         return expand(
-            "results/untrimmed/{S}_{R}.sorted.fastq.gz", S=wildcards.sample, R=["fq1", "fq2"]
+            "results/untrimmed/{S}_{R}.sorted.fastq.gz",
+            S=wildcards.sample,
+            R=["fq1", "fq2"]
         )
     else:
         return umi_read

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -50,7 +50,7 @@ rule annotate_umis:
     output:
         temp("results/mapped/{aligner}/{sample}.annotated.bam"),
     params:
-        extra=get_umi_read_structure,
+        extra=get_annotate_umis_params,
     log:
         "logs/fgbio/annotate_bam/{aligner}/{sample}.log",
     wrapper:

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -17,13 +17,13 @@ rule map_reads:
 
 rule query_sort_reads:
     input:
-        "results/mapped/{aligner}/{sample}.bam"
+        "results/mapped/{aligner}/{sample}.bam",
     output:
-        temp("results/mapped/{aligner}/{sample}.sorted.bam")
+        temp("results/mapped/{aligner}/{sample}.sorted.bam"),
     conda:
         "../envs/fgbio.yaml"
     log:
-        "logs/fgbio/sort_bam/{aligner}_{sample}.log"
+        "logs/fgbio/sort_bam/{aligner}_{sample}.log",
     shell:
         "fgbio SortBam -i {input} -o {output} -s Queryname 2> {log}"
 
@@ -43,13 +43,13 @@ rule merge_untrimmed_fastqs:
 
 rule sort_untrimmed_fastqs:
     input:
-        "results/untrimmed/{sample}_{read}.fastq.gz"
+        "results/untrimmed/{sample}_{read}.fastq.gz",
     output:
-        temp("results/untrimmed/{sample}_{read}.sorted.fastq.gz")
+        temp("results/untrimmed/{sample}_{read}.sorted.fastq.gz"),
     conda:
         "../envs/fgbio.yaml"
     log:
-        "logs/fgbio/sort_fastq/{sample}_{read}.log"
+        "logs/fgbio/sort_fastq/{sample}_{read}.log",
     shell:
         "fgbio SortFastq -i {input} -o {output} 2> {log}"
 

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -9,10 +9,10 @@ rule map_reads:
     params:
         extra=get_read_group,
         sorting=get_map_reads_sorting_params,
-        sort_order=lambda wc: get_map_reads_sorting_params(wc, order_param=True),
+        sort_order=lambda wc: get_map_reads_sorting_params(wc, ordering=True),
     threads: 8
     wrapper:
-        "v3.7.0-29-ge7ff82c/bio/bwa/mem"
+        "v3.8.0/bio/bwa/mem"
 
 
 rule merge_untrimmed_fastqs:

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -8,24 +8,11 @@ rule map_reads:
         "logs/bwa_mem/{sample}.log",
     params:
         extra=get_read_group,
-        sorting="samtools",
-        sort_order="coordinate",
+        sorting=get_map_reads_sorting_params,
+        sort_order=lambda wc: get_map_reads_sorting_params(wc, order_param=True),
     threads: 8
     wrapper:
-        "v2.3.2/bio/bwa/mem"
-
-
-rule query_sort_reads:
-    input:
-        "results/mapped/{aligner}/{sample}.bam",
-    output:
-        temp("results/mapped/{aligner}/{sample}.sorted.bam"),
-    conda:
-        "../envs/fgbio.yaml"
-    log:
-        "logs/fgbio/sort_bam/{aligner}_{sample}.log",
-    shell:
-        "fgbio SortBam -i {input} -o {output} -s Queryname 2> {log}"
+        "v3.7.0-29-ge7ff82c/bio/bwa/mem"
 
 
 rule merge_untrimmed_fastqs:
@@ -33,6 +20,8 @@ rule merge_untrimmed_fastqs:
         get_untrimmed_fastqs,
     output:
         temp("results/untrimmed/{sample}_{read}.fastq.gz"),
+    conda:
+        "../envs/fgbio.yaml"
     log:
         "logs/merge-fastqs/untrimmed/{sample}_{read}.log",
     wildcard_constraints:
@@ -56,7 +45,7 @@ rule sort_untrimmed_fastqs:
 
 rule annotate_umis:
     input:
-        bam="results/mapped/{aligner}/{sample}.sorted.bam",
+        bam="results/mapped/{aligner}/{sample}.bam",
         umi=get_umi_fastq,
     output:
         temp("results/mapped/{aligner}/{sample}.annotated.bam"),

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -48,7 +48,7 @@ rule annotate_umis:
         bam="results/mapped/{aligner}/{sample}.bam",
         umi=get_umi_fastq,
     output:
-        temp("results/mapped/{aligner}/{sample}.annotated.bam"),
+        pipe("pipe/{aligner}/{sample}.annotated.bam"),
     params:
         extra=get_annotate_umis_params,
     log:
@@ -59,9 +59,9 @@ rule annotate_umis:
 
 rule sort_annotated_reads:
     input:
-        "results/mapped/{aligner}/{sample}.annotated.bam",
+        "pipe/{aligner}/{sample}.annotated.bam",
     output:
-        temp("results/mapped/{aligner}/{sample}.annotated.sorted.bam"),
+        temp("results/mapped/{aligner}/{sample}.annotated.bam"),
     log:
         "logs/samtools_sort/{aligner}_{sample}.log",
     threads: 8


### PR DESCRIPTION
For large samples `fgbio AnnotateBamWithUmis` fails due to memory issues.
This happens as fgbio loads the fully uncompressed UMI fastq file into memory.
We already tried to fix this in a previous PR (https://github.com/snakemake-workflows/dna-seq-varlociraptor/pull/262) by dynamically assigning more memory based on input file size.
Still this does not suffice in many cases.

To get this fixed fgbio suggests a [best practice](https://github.com/fulcrumgenomics/fgbio/blob/main/docs/best-practice-consensus-pipeline.md#phase-1-fastq---grouped-bam) where raw reads are transformed into unmapped bam files while annotating UMIs at the same time.
In our case this is not feasible as reads need to be adapter trimmed by cutadapt first.
But in case of Qiagen reads the UMI lies in front of the adapter sequence ([source](https://resources.qiagenbioinformatics.com/manuals/biomedicalgenomicsanalysis/2110/index.php?manual=Create_custom_Trim_adapter_list_optional.html)) and therefore can not be annotated while transforming the reads into ubam.

Alternatively, `fgbio AnnotateBamWithUmis` allows to input a queryname sorted bam and fastq file reading the UMIs sequentially from the fastq file, first.
fastq files can be sorted by `fgbio SortFastq`. I intended to directly sort the mapped reads by queryname when running `map_reads` but it showed that queryname sorting differs between `fgbio` and `samtools` receiving incompatible files.
So, it is necessary to reorder the mapped reads by `fgbio SortBam` before annotating UMIs.

PS: Not sure if we treat this as fix or feature