### PR TITLE
fix: fusion candidate filtering and add HGVSc to variant datavzrd report

### DIFF
--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -221,6 +221,9 @@ views:
                     aux-domain-columns: ?list(params.groups)
             hgvsg:
               display-mode: hidden
+            hgvsc:
+              optional: true
+              display-mode: hidden
 
   ?for group in params.groups:
     ?f"{group}-coding":
@@ -324,6 +327,8 @@ views:
           swissprot:
             display-mode: hidden
           hgvsg:
+            display-mode: hidden
+          hgvsc:
             display-mode: detail
           chromosome:
             display-mode: detail
@@ -507,6 +512,9 @@ views:
           binned max vaf:
             display-mode: hidden
           hgvsg:
+            optional: true
+            display-mode: hidden
+          hgvsc:
             optional: true
             display-mode: detail
           chromosome:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1023,6 +1023,7 @@ def get_vembrane_config(wildcards, input):
             {"name": "protein position", "expr": "ANN['Protein_position'].raw"},
             {"name": "protein alteration (short)", "expr": "ANN['Amino_acids']"},
             "HGVSg",
+            "HGVSc",
             "Consequence",
             "CANONICAL",
             "MANE_PLUS_CLINICAL",

--- a/workflow/rules/filtering.smk
+++ b/workflow/rules/filtering.smk
@@ -13,7 +13,7 @@ rule filter_candidates_by_annotation:
         "../envs/vembrane.yaml"
     shell:
         "(bcftools norm -Ou --do-not-normalize --multiallelics -any {input} | "
-        'vembrane filter {params.aux} "{params.filter}" --output-fmt bcf --output {output}) &> {log}'
+        'vembrane filter {params.aux} "{params.filter}" | bcftools sort -Ob > {output}) &> {log}'
 
 
 rule filter_by_annotation:


### PR DESCRIPTION
The fusion calling workflow fails in case of candidate calls being filtered.
This happens as `vembrane filter` does not keep entries coordinate sorted but groups records by fusion mates.
Therefore `varlociraptor preprocess` fails as it expects coordinate sorted input.

Further a minor change to the variant calling datavzrd report has been made.
The report now shows HGVSc instead of HGVSg values. HGVSg values are still used for Genome Nexus linkouts but the entry itself is now hidden.