### PR TITLE
feat: download alphamissense scores

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -206,10 +206,7 @@ annotations:
         # For integration of SpliceAI preprocessed snv and indel scores (including index files) are required. 
         # Scores are available on https://basespace.illumina.com/s/otSPW8hnhaZR
         #- SpliceAI,snv=<path/to/spliceai_scores.raw.snv.hg38.vcf.gz,indel=<path/to/spliceai_scores.raw.indel.hg38.vcf.gz>
-        # For annotation of AlphaMissense scores a tsv-file containing processed scores is required.
-        # Scores are available on https://zenodo.org/records/10813168
-        # A tabix index is required and can be created by calling `tabix -s 1 -b 2 -e 2 -f -S 1 AlphaMissense_hg38.tsv.gz`
-        #- AlphaMissense,file=<path/to/AlphaMissense_hg38.tsv.gz>
+        #- AlphaMissense
 
 # printing of variants in a table format (might be deprecated soon)
 tables:

--- a/workflow/rules/annotation.smk
+++ b/workflow/rules/annotation.smk
@@ -29,6 +29,8 @@ rule annotate_variants:
         plugins="resources/vep/plugins",
         revel=lambda wc: get_plugin_aux("REVEL"),
         revel_tbi=lambda wc: get_plugin_aux("REVEL", True),
+        alphamissense=lambda wc: get_plugin_aux("AlphaMissense"),
+        alphamissense_tbi=lambda wc: get_plugin_aux("AlphaMissense", True),
         fasta=genome,
         fai=genome_fai,
     output:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -725,9 +725,12 @@ def get_vep_threads():
 
 def get_plugin_aux(plugin, index=False):
     if plugin in config["annotations"]["vep"]["final_calls"]["plugins"]:
+        suffix = ".tbi" if index else ""
         if plugin == "REVEL":
             suffix = ".tbi" if index else ""
             return "resources/revel_scores.tsv.gz{suffix}".format(suffix=suffix)
+        if plugin == "AlphaMissense":
+            return "resources/alphamissense_scores.tsv.gz{suffix}".format(suffix=suffix)
     return []
 
 
@@ -982,10 +985,26 @@ def get_tabix_params(wildcards):
     raise ValueError("Invalid format for tabix: {}".format(wildcards.format))
 
 
-def get_tabix_revel_params():
-    # Indexing of REVEL-score file where the column depends on the reference
-    column = 2 if config["ref"]["build"] == "GRCh37" else 3
-    return f"-f -s 1 -b {column} -e {column}"
+def get_tabix_plugin_params(plugin):
+    if plugin == "revel"
+        # Indexing of REVEL-score file where the column depends on the reference
+        column = 2 if config["ref"]["build"] == "GRCh37" else 3
+        return f"-f -s 1 -b {column} -e {column}"
+    else if plugin == "alphamissense":
+        return "-f -s 1 -b 2 -e 2 -f -S 1"
+    else:
+        WorkflowError("Unsupported plugin for obtaining tabix parameteres")
+
+def get_alphamissense_url():
+    if config["ref"]["build"] == "GRCh37":
+        build = "hg19"
+    else if config["ref"]["build"] == "GRCh38"
+        build = "hg38"
+    else:
+        WorkflowError("Invalid reference for AlphaMissense annotation. Only GRCh37 and GRCh38 supported.")
+    return f"https://zenodo.org/records/10813168/files/AlphaMissense_{build}.tsv.gz"
+
+
 
 
 def get_untrimmed_fastqs(wc):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -986,25 +986,26 @@ def get_tabix_params(wildcards):
 
 
 def get_tabix_plugin_params(plugin):
-    if plugin == "revel"
+    if plugin == "revel":
         # Indexing of REVEL-score file where the column depends on the reference
         column = 2 if config["ref"]["build"] == "GRCh37" else 3
         return f"-f -s 1 -b {column} -e {column}"
-    else if plugin == "alphamissense":
+    elif plugin == "alphamissense":
         return "-f -s 1 -b 2 -e 2 -f -S 1"
     else:
         WorkflowError("Unsupported plugin for obtaining tabix parameteres")
 
+
 def get_alphamissense_url():
     if config["ref"]["build"] == "GRCh37":
         build = "hg19"
-    else if config["ref"]["build"] == "GRCh38"
+    elif config["ref"]["build"] == "GRCh38":
         build = "hg38"
     else:
-        WorkflowError("Invalid reference for AlphaMissense annotation. Only GRCh37 and GRCh38 supported.")
+        WorkflowError(
+            "Invalid reference for AlphaMissense annotation. Only GRCh37 and GRCh38 supported."
+        )
     return f"https://zenodo.org/records/10813168/files/AlphaMissense_{build}.tsv.gz"
-
-
 
 
 def get_untrimmed_fastqs(wc):

--- a/workflow/rules/plugins.smk
+++ b/workflow/rules/plugins.smk
@@ -35,12 +35,25 @@ rule process_revel_scores:
         """
 
 
-use rule tabix_known_variants as tabix_revel_scores with:
-    input:
-        "resources/revel_scores.tsv.gz",
+rule download_alphamissense_scores:
     output:
-        "resources/revel_scores.tsv.gz.tbi",
+        "resources/alphamissense_scores.tsv.gz",
     params:
-        get_tabix_revel_params(),
+        url=get_alphamissense_url(),
+    conda:
+        "../envs/curl.yaml"
+    shell:
+        """
+        curl {params.url} -o {output} &> {log}
+        """
+
+
+use rule tabix_known_variants as tabix_plugin_scores with:
+    input:
+        "resources/{plugin}_scores.tsv.gz",
+    output:
+        "resources/{plugin}_scores.tsv.gz.tbi",
+    params:
+        lambda wc: get_tabix_plugin_params(wc.plugin),
     log:
-        "logs/tabix/revel.log",
+        "logs/tabix/{plugin}.log",


### PR DESCRIPTION
For annotation AlphaMissense scores with VEP scores need to be downloaded and index first.
This has been a manual step before.
To improve this further scores are now download from Zenodo for hg38 and hg19.

