### PR TITLE
fix: minor fixes

### DIFF
--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -468,8 +468,10 @@ views:
             display-mode: hidden
           chromosome:
             display-mode: detail
+          end position:
+            display-mode: detail
           position:
-             display-mode: detail
+            display-mode: detail
           reference allele:
             display-mode: detail
           alternative allele:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1053,7 +1053,7 @@ def get_vembrane_config(wildcards, input):
             {"name": "mateid", "expr": "INFO['MATEID'][0]"},
             {"name": "feature_name", "expr": "INFO['GENE_NAME']"},
             {"name": "feature_id", "expr": "INFO['GENE_ID']"},
-            "EXON_NUMBER",
+            {"name": "exon", "expr": "INFO['EXON_NUMBER'][0]"},
         ]
         append_items(info_fields, "INFO['{}']".format, lambda x: x.lower())
     else:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -6,6 +6,8 @@ rule fastqc:
         zip="results/qc/fastqc/{sample}/{unit}.{fq}_fastqc.zip",  # the suffix _fastqc.zip is necessary for multiqc to find the file. If not using multiqc, you are free to choose an arbitrary filename
     log:
         "logs/fastqc/{sample}/{unit}.{fq}.log",
+    resources:
+        mem_mb=1024,
     wrapper:
         "v2.10.0/bio/fastqc"
 


### PR DESCRIPTION
Changes:

- impr: column `end position` for non-coding variants has been moved to detail view
- fix: correct processing of exons during fusion calling (became broken by previous PR)
- fix: increased memory for fastqc as it failed with OutOfMemory error on larger samples.@dawidkrzeciesa tested it for WES samples (~18GB fastqs) and 256MB were sufficient. Setting it to 1024MB should also be sufficient for WGS data. 