### PR TITLE
fix: always use the same type for label list in datavzrd config

### DIFF
--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -97,7 +97,7 @@ views:
   ?if input.gene_oncoprint:
     ?for view in ["gene-oncoprint"] + list(params.labels.index.values):
       __variables__:
-        labels: ?params.group_annotations.columns.values if view == "gene-oncoprint" else [view]
+        labels: ?params.group_annotations.columns.values.tolist() if view == "gene-oncoprint" else [view]
       ?"overview" if view == "gene-oncoprint" else f"by {view}":
         ?if view == "gene-oncoprint":
           desc: |
@@ -114,7 +114,7 @@ views:
             """
         dataset: ?view
         render-table:
-          ?if len(labels) > 0:
+          ?if labels:
             headers:
               ?for i, annotation in enumerate(labels):
                 ?i + 1:

--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -114,7 +114,7 @@ views:
             """
         dataset: ?view
         render-table:
-          ?if labels:
+          ?if len(labels) > 0:
             headers:
               ?for i, annotation in enumerate(labels):
                 ?i + 1:


### PR DESCRIPTION
This avoids downstream errors when checking for emptyness.