### PR TITLE
fix: use list type for group annotations in datavzrd config

### DIFF
--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -157,7 +157,7 @@ views:
         dataset: ?f"variant-oncoprint-{gene}"
         hidden: true
         render-table:
-          ?if params.group_annotations.columns.values:
+          ?if params.group_annotations.columns.values.tolist():
             headers:
               ?for i, annotation in enumerate(params.group_annotations.columns.values):
                 ?i + 1:


### PR DESCRIPTION
This fixes the type error originating from rendering group annotations in datavzrd config.