### PR TITLE
fix: make the `aux-files` example use the existing `ANN` field `SYMBOL`

### DIFF
--- a/.test/config-no-candidate-filtering/config.yaml
+++ b/.test/config-no-candidate-filtering/config.yaml
@@ -48,7 +48,7 @@ calling:
     with_aux:
       aux-files: 
         super_interesting_genes: config-no-candidate-filtering/super_interesting_genes.tsv
-      expression: "ANN['GENE'] in AUX['super_interesting_genes']"
+      expression: "ANN['SYMBOL'] in AUX['super_interesting_genes']"
   fdr-control:
     threshold: 0.05
     events: 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -119,7 +119,7 @@ calling:
     gene_list_filter:
       aux-files:
         super_interesting_genes: "config/super_interesting_genes.tsv"
-      expression: "ANN['GENE'] in AUX['super_interesting_genes']"
+      expression: "ANN['SYMBOL'] in AUX['super_interesting_genes']"
   fdr-control:
     threshold: 0.05
     # denote FDR control mode, see https://varlociraptor.github.io/docs/filtering


### PR DESCRIPTION
This has tripped up multiple people by now, so let's fix the example in the standard `config/config.yaml` that everybody gets upon module-based deployment.