### PR TITLE
fix: fix excluding events from the report

### DIFF
--- a/.test/config-simple/config.yaml
+++ b/.test/config-simple/config.yaml
@@ -50,6 +50,7 @@ calling:
     local: true
     events: 
       present:
+        report: false
         varlociraptor: 
           - x
           - y

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -150,20 +150,7 @@ def get_final_output(wildcards):
                         expand(
                             "results/datavzrd-report/{batch}.{event}.{calling_type}.fdr-controlled",
                             batch=get_report_batches(calling_type),
-                            event=get_calling_events(calling_type),
-                            calling_type=calling_type,
-                        )
-                    )
-                else:
-                    final_output.extend(
-                        expand(
-                            "results/final-calls/{group}.{event}.{calling_type}.fdr-controlled.bcf",
-                            group=(
-                                variants_groups
-                                if calling_type == "variants"
-                                else fusions_groups
-                            ),
-                            event=get_calling_events(calling_type),
+                            event=event,
                             calling_type=calling_type,
                         )
                     )

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -154,6 +154,19 @@ def get_final_output(wildcards):
                             calling_type=calling_type,
                         )
                     )
+                else:
+                    final_output.extend(
+                        expand(
+                            "results/final-calls/{group}.{event}.{calling_type}.fdr-controlled.bcf",
+                            group=(
+                                variants_groups
+                                if calling_type == "variants"
+                                else fusions_groups
+                            ),
+                            event=event,
+                            calling_type=calling_type,
+                        )
+                    )
         else:
             final_output.extend(
                 expand(

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -140,7 +140,7 @@ def get_final_output(wildcards):
 
     for calling_type in calling_types:
         if config["report"]["activate"]:
-            for event in config["calling"]["fdr-control"]["events"]:
+            for event in get_calling_events(calling_type):
                 if lookup(
                     dpath=f"calling/fdr-control/events/{event}/report",
                     within=config,


### PR DESCRIPTION
Before excluding events from the report did not work as it was thought. All the events that had `False` for `report` generation in the config still had datavzrd reports, because `get_calling_events(calling_type)` always returned all events. This fix ensures that only `True` events have datavzrd reports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved output file path generation for fusions and variants.
	- Enhanced handling of group samples and aliases with new helper functions.
	- Streamlined logic for generating reports and managing mutational burden targets.
	- New configuration options for reporting within false discovery rate control.

- **Bug Fixes**
	- Corrected event name retrieval in output paths.
	- Fixed indentation issues in configuration files.

- **Refactor**
	- Simplified and clarified the output generation logic for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->