### PR TITLE
perf: group calling jobs per patient/sample-group such that they are submitted to the same cluster/cloud nodes in order to save I/O

### DIFF
--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -34,7 +34,8 @@ rule varlociraptor_alignment_properties:
         "logs/varlociraptor/estimate-alignment-properties/{group}/{sample}.log",
     conda:
         "../envs/varlociraptor.yaml"
-    group: "calling"
+    group:
+        "calling"
     shell:
         "varlociraptor estimate alignment-properties {input.ref} --bam {input.bam} > {output} 2> {log}"
 
@@ -59,7 +60,8 @@ rule varlociraptor_preprocess:
         "benchmarks/varlociraptor/preprocess/{group}/{sample}.{caller}.{scatteritem}.tsv"
     conda:
         "../envs/varlociraptor.yaml"
-    group: "calling"
+    group:
+        "calling"
     shell:
         "varlociraptor preprocess variants --candidates {input.candidates} {params.extra} "
         "--alignment-properties {input.alignment_props} {input.ref} --bam {input.bam} --output {output} "
@@ -90,7 +92,8 @@ rule varlociraptor_call:
         "../envs/varlociraptor.yaml"
     benchmark:
         "benchmarks/varlociraptor/call/{group}.{caller}.{scatteritem}.tsv"
-    group: "calling"
+    group:
+        "calling"
     shell:
         "(varlociraptor call variants {params.extra} generic --obs {params.obs}"
         " --scenario {input.scenario} {params.postprocess} {output}) 2> {log}"

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -34,6 +34,7 @@ rule varlociraptor_alignment_properties:
         "logs/varlociraptor/estimate-alignment-properties/{group}/{sample}.log",
     conda:
         "../envs/varlociraptor.yaml"
+    group: "calling"
     shell:
         "varlociraptor estimate alignment-properties {input.ref} --bam {input.bam} > {output} 2> {log}"
 
@@ -42,7 +43,7 @@ rule varlociraptor_preprocess:
     input:
         ref=genome,
         ref_idx=genome_fai,
-        candidates=lambda wc: get_candidate_calls,
+        candidates=get_candidate_calls,
         bam="results/recal/{sample}.bam",
         bai="results/recal/{sample}.bai",
         alignment_props="results/alignment-properties/{group}/{sample}.json",
@@ -58,6 +59,7 @@ rule varlociraptor_preprocess:
         "benchmarks/varlociraptor/preprocess/{group}/{sample}.{caller}.{scatteritem}.tsv"
     conda:
         "../envs/varlociraptor.yaml"
+    group: "calling"
     shell:
         "varlociraptor preprocess variants --candidates {input.candidates} {params.extra} "
         "--alignment-properties {input.alignment_props} {input.ref} --bam {input.bam} --output {output} "
@@ -88,6 +90,7 @@ rule varlociraptor_call:
         "../envs/varlociraptor.yaml"
     benchmark:
         "benchmarks/varlociraptor/call/{group}.{caller}.{scatteritem}.tsv"
+    group: "calling"
     shell:
         "(varlociraptor call variants {params.extra} generic --obs {params.obs}"
         " --scenario {input.scenario} {params.postprocess} {output}) 2> {log}"

--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -83,6 +83,7 @@ rule scatter_candidates:
         "logs/scatter-candidates/{group}.{caller}.log",
     conda:
         "../envs/rbt.yaml"
-    group: "calling"
+    group:
+        "calling"
     shell:
         "rbt vcf-split {input} {output}"

--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -83,5 +83,6 @@ rule scatter_candidates:
         "logs/scatter-candidates/{group}.{caller}.log",
     conda:
         "../envs/rbt.yaml"
+    group: "calling"
     shell:
         "rbt vcf-split {input} {output}"

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -5,7 +5,7 @@ rule get_sra:
     log:
         "logs/get-sra/{accession}.log",
     wrapper:
-        "v2.3.2/bio/sra-tools/fasterq-dump"
+        "v5.0.2/bio/sra-tools/fasterq-dump"
 
 
 rule cutadapt_pipe:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `group` parameter to enhance organization and tracking of related outputs in several rules.
	- Added a `group` declaration to the `scatter_candidates` rule for improved categorization.

- **Improvements**
	- Simplified input handling for the `varlociraptor_preprocess` rule by updating the `candidates` input reference.
	- Updated the `get_sra` rule to use a newer version of the `fasterq-dump` wrapper for processing SRA data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->