### PR TITLE
fix: fix filtering primerless reads by pinning rust-script

### DIFF
--- a/workflow/envs/filter_reads.yaml
+++ b/workflow/envs/filter_reads.yaml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
 dependencies:
-  - rust-script >=0.17.0
+  - rust-script =0.22
   - rust >=1.58
   - cryptography >=36.0
   - c-compiler =1.3

--- a/workflow/envs/filter_reads.yaml
+++ b/workflow/envs/filter_reads.yaml
@@ -1,6 +1,7 @@
 channels:
   - conda-forge
 dependencies:
+  # update rust-script to 0.35 once it is supported by snakemake
   - rust-script =0.22
   - rust >=1.58
   - cryptography >=36.0

--- a/workflow/envs/filter_reads.yaml
+++ b/workflow/envs/filter_reads.yaml
@@ -1,7 +1,8 @@
 channels:
   - conda-forge
 dependencies:
-  # update rust-script to 0.35 once it is supported by snakemake
+  # TODO: update rust-script to 0.35 once it is supported by snakemake, see:
+  #   https://github.com/snakemake/snakemake/issues/3183
   - rust-script =0.22
   - rust >=1.58
   - cryptography >=36.0


### PR DESCRIPTION
filtering primerless reads lately started to fail as there was a new release of `rust-script =0.35` on conda-forge.
That version causes an issue when executing rust scripts returning `error: unexpected argument '--features' found, tip: to pass '--features' as a value, use '-- --features'`.
While pinning the version to the only previous version `0.22`  available on conda-forge we should make adjustments to the script in the future to be compatible with version `0.35` in the future.

The issue has already been discussed here: https://github.com/snakemake/snakemake/issues/3183
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `rust-script` dependency to ensure compatibility with the latest features.
	- Added a note for future updates to `rust-script` once supported by Snakemake.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->