### PR TITLE
feat: support for samples w/ and w/o primers

### DIFF
--- a/.test/config-chm-eval/config.yaml
+++ b/.test/config-chm-eval/config.yaml
@@ -15,7 +15,6 @@ ref:
 
 primers:
   trimming:
-    activate: false
     primers_fa1: ""
     primers_fa2: ""
     library_length: 0

--- a/.test/config-giab/config.yaml
+++ b/.test/config-giab/config.yaml
@@ -17,8 +17,8 @@ ref:
 primers:
   trimming:
     # path to fasta files containg primer sequences
-    primers_fa1: "path/to/primer-fa1"
-    primers_fa2: "path/to/primer-fa2"
+    primers_fa1: ""
+    primers_fa2: ""
     # Library mean + error determines the maximum insert size between the outer primer ends.
     # Specify 0 to have yara autodetect the primer library insert size error.
     library_error: 0

--- a/.test/config-giab/config.yaml
+++ b/.test/config-giab/config.yaml
@@ -16,7 +16,6 @@ ref:
 
 primers:
   trimming:
-    activate: false
     # path to fasta files containg primer sequences
     primers_fa1: "path/to/primer-fa1"
     primers_fa2: "path/to/primer-fa2"

--- a/.test/config-no-candidate-filtering/config.yaml
+++ b/.test/config-no-candidate-filtering/config.yaml
@@ -15,7 +15,6 @@ ref:
 
 primers:
   trimming:
-    activate: false
     primers_fa1: ""
     primers_fa2: ""
     library_length: 0

--- a/.test/config-simple/config.yaml
+++ b/.test/config-simple/config.yaml
@@ -15,7 +15,6 @@ ref:
 
 primers:
   trimming:
-    activate: false
     primers_fa1: ""
     primers_fa2: ""
     library_error: 0

--- a/.test/config-sra/config.yaml
+++ b/.test/config-sra/config.yaml
@@ -15,7 +15,6 @@ ref:
 
 primers:
   trimming:
-    activate: false
     primers_fa1: ""
     primers_fa2: ""
     library_length: 0

--- a/.test/config-target-regions/config.yaml
+++ b/.test/config-target-regions/config.yaml
@@ -17,7 +17,6 @@ ref:
 
 primers:
   trimming:
-    activate: false
     primers_fa1: ""
     primers_fa2: ""
     library_length: 0

--- a/.test/config-target-regions/config_multiple_beds.yaml
+++ b/.test/config-target-regions/config_multiple_beds.yaml
@@ -19,7 +19,6 @@ ref:
 
 primers:
   trimming:
-    activate: false
     primers_fa1: ""
     primers_fa2: ""
     library_length: 0

--- a/.test/config_primers/config.yaml
+++ b/.test/config_primers/config.yaml
@@ -16,7 +16,6 @@ ref:
 
 primers:
   trimming:
-    activate: true
     primers_fa1: "a.scerevisiae.1_primers.fq"
     primers_fa2: "a.scerevisiae.2_primers.fq"
     library_length: 400

--- a/config/README.md
+++ b/config/README.md
@@ -46,6 +46,7 @@ Defining primers directly in the config file is prefered when all samples come f
 In case of different panels, primers have to be set panel-wise in a seperate tsv-file.
 For each panel the following columns need to be set: `panel`, `fa1` and `fa2` (optional).
 Additionally, for each sample the corresponding panel must be defined in `samples.tsv` (column `panel`).
+If a panel is not provided for a sample, trimming will not be performed on that sample. 
 For single primer trimming only, the first entry in the config (respective in the tsv file) needs to be defined.
 
 # Annotating UMIS

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -32,7 +32,6 @@ ref:
 
 primers:
   trimming:
-    activate: false
     # path to fasta files containg primer sequences
     primers_fa1: "path/to/primer-fa1"
     primers_fa2: "path/to/primer-fa2"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -30,11 +30,13 @@ ref:
   # This is usually only relevant for testing.
   # chromosome: 21
 
+# Trimming will be applied if global primer sequences are
+# provided or primer panels are set in samplesheet
 primers:
   trimming:
-    # path to fasta files containg primer sequences
-    primers_fa1: "path/to/primer-fa1"
-    primers_fa2: "path/to/primer-fa2"
+    # path to fasta files containing primer sequences
+    primers_fa1: ""
+    primers_fa2: ""
     # optional primer file allowing to define primers per sample
     # overwrites primers_fa1 and primers_fa2
     # the tsv file requires three fields: panel, fa1 and fa2 (optional)

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1373,7 +1373,6 @@ def sample_has_primers(wildcards):
     if config["primers"]["trimming"].get("primers_fa1"):
         return True
 
-   
     # Check for primers in the sample's panel
     sample_name = wildcards.sample
     if (

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1369,13 +1369,9 @@ def get_umi_fastq(wildcards):
 
 
 def sample_has_primers(wildcards):
-    # Check global primers trimming configuration
-    if config["primers"]["trimming"].get("primers_fa1"):
-        return True
-
-    # Check for primers in the sample's panel
     sample_name = wildcards.sample
-    if (
+
+    if config["primers"]["trimming"].get("primers_fa1") or (
         "panel" in samples.columns
         and samples.loc[samples["sample_name"] == sample_name, "panel"].notna().any()
     ):
@@ -1384,7 +1380,6 @@ def sample_has_primers(wildcards):
                 f"Primer trimming is only available for paired-end data. Sample '{sample_name}' is not paired-end."
             )
         return True
-
     return False
 
 

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -20,8 +20,6 @@ rule merge_untrimmed_fastqs:
         get_untrimmed_fastqs,
     output:
         temp("results/untrimmed/{sample}_{read}.fastq.gz"),
-    conda:
-        "../envs/fgbio.yaml"
     log:
         "logs/merge-fastqs/untrimmed/{sample}_{read}.log",
     wildcard_constraints:


### PR DESCRIPTION
In some experiments, there are samples with and without primers. However, this case was not previously supported because the workflow always expects a panel containing primers to be provided in the `samples.tsv` file. To address this, the workflow now dynamically checks if a panel is provided for primer trimming. Nevertheless, primer trimming must still be activated in the configuration file.

We should consider whether the primer trimming section in the configuration file is still necessary, or if trimming can be inferred from the presence of a panel in the samplesheet. However, we should retain the primer section for setting a custom library length and specifying the paths to the primer files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a function to check for primer presence in sample data.
	- Enhanced logic for handling sample data and file outputs.
	- Added new requirements for sample and unit sheets in configuration.
	- Enabled primer trimming and mutational burden estimation in configuration files.
	- Activated both `delly` and `freebayes` for variant calling in multiple configurations.

- **Bug Fixes**
	- Improved error handling for sample and unit combinations.

- **Chores**
	- Removed environment specification from the `merge_untrimmed_fastqs` rule.
	- Added execution order dependency between `apply_bqsr` and `bam_index` rules.
	- Updated comments for clarity throughout configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->