### PR TITLE
feat: allow setting of custom alignment properties

### DIFF
--- a/.test/config-chm-eval/config.yaml
+++ b/.test/config-chm-eval/config.yaml
@@ -184,3 +184,8 @@ report:
   stratify:
     activate: false
     by-column: condition
+
+custom_alignment_properties:
+  activate: false
+  column: "panel"
+  tsv: "config_alignment_properties.tsv"

--- a/.test/config-chm-eval/config.yaml
+++ b/.test/config-chm-eval/config.yaml
@@ -188,4 +188,4 @@ report:
 custom_alignment_properties:
   activate: false
   column: "panel"
-  tsv: "config_alignment_properties.tsv"
+  tsv: ""

--- a/.test/config-giab/config.yaml
+++ b/.test/config-giab/config.yaml
@@ -161,4 +161,4 @@ gene_coverage:
 custom_alignment_properties:
   activate: false
   column: "panel"
-  tsv: "config_alignment_properties.tsv"
+  tsv: ""

--- a/.test/config-giab/config.yaml
+++ b/.test/config-giab/config.yaml
@@ -157,3 +157,8 @@ params:
 
 gene_coverage:
   min_avg_coverage: 5
+
+custom_alignment_properties:
+  activate: false
+  column: "panel"
+  tsv: "config_alignment_properties.tsv"

--- a/.test/config-no-candidate-filtering/config.yaml
+++ b/.test/config-no-candidate-filtering/config.yaml
@@ -123,3 +123,8 @@ report:
   stratify:
     activate: false
     by-column: condition
+
+custom_alignment_properties:
+  activate: false
+  column: "panel"
+  tsv: "config_alignment_properties.tsv"

--- a/.test/config-no-candidate-filtering/config.yaml
+++ b/.test/config-no-candidate-filtering/config.yaml
@@ -127,4 +127,4 @@ report:
 custom_alignment_properties:
   activate: false
   column: "panel"
-  tsv: "config_alignment_properties.tsv"
+  tsv: ""

--- a/.test/config-simple/config.yaml
+++ b/.test/config-simple/config.yaml
@@ -127,3 +127,8 @@ tables:
     coverage: true
     event_prob: true
   generate_excel: true
+
+custom_alignment_properties:
+  activate: false
+  column: "panel"
+  tsv: "config_alignment_properties.tsv"

--- a/.test/config-simple/config.yaml
+++ b/.test/config-simple/config.yaml
@@ -131,4 +131,4 @@ tables:
 custom_alignment_properties:
   activate: false
   column: "panel"
-  tsv: "config_alignment_properties.tsv"
+  tsv: ""

--- a/.test/config-sra/config.yaml
+++ b/.test/config-sra/config.yaml
@@ -113,3 +113,8 @@ tables:
     coverage: true
     event_prob: true
   generate_excel: true
+  
+custom_alignment_properties:
+  activate: false
+  column: "panel"
+  tsv: "config_alignment_properties.tsv"

--- a/.test/config-sra/config.yaml
+++ b/.test/config-sra/config.yaml
@@ -117,4 +117,4 @@ tables:
 custom_alignment_properties:
   activate: false
   column: "panel"
-  tsv: "config_alignment_properties.tsv"
+  tsv: ""

--- a/.test/config-target-regions/config.yaml
+++ b/.test/config-target-regions/config.yaml
@@ -126,3 +126,8 @@ tables:
     coverage: true
     event_prob: true
   generate_excel: true
+
+custom_alignment_properties:
+  activate: false
+  column: "panel"
+  tsv: "config_alignment_properties.tsv"

--- a/.test/config-target-regions/config.yaml
+++ b/.test/config-target-regions/config.yaml
@@ -130,4 +130,4 @@ tables:
 custom_alignment_properties:
   activate: false
   column: "panel"
-  tsv: "config_alignment_properties.tsv"
+  tsv: ""

--- a/.test/config-target-regions/config_multiple_beds.yaml
+++ b/.test/config-target-regions/config_multiple_beds.yaml
@@ -128,4 +128,4 @@ tables:
 custom_alignment_properties:
   activate: false
   column: "panel"
-  tsv: "config_alignment_properties.tsv"
+  tsv: ""

--- a/.test/config-target-regions/config_multiple_beds.yaml
+++ b/.test/config-target-regions/config_multiple_beds.yaml
@@ -124,3 +124,8 @@ tables:
     coverage: true
     event_prob: true
   generate_excel: true
+
+custom_alignment_properties:
+  activate: false
+  column: "panel"
+  tsv: "config_alignment_properties.tsv"

--- a/.test/config_primers/config.yaml
+++ b/.test/config_primers/config.yaml
@@ -116,3 +116,8 @@ tables:
     coverage: true
     event_prob: true
   generate_excel: true
+
+custom_alignment_properties:
+  activate: false
+  column: "panel"
+  tsv: "config_alignment_properties.tsv"

--- a/.test/config_primers/config.yaml
+++ b/.test/config_primers/config.yaml
@@ -120,4 +120,4 @@ tables:
 custom_alignment_properties:
   activate: false
   column: "panel"
-  tsv: "config_alignment_properties.tsv"
+  tsv: ""

--- a/config/alignment_properties.tsv
+++ b/config/alignment_properties.tsv
@@ -1,0 +1,1 @@
+name	path

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -282,3 +282,12 @@ params:
   freebayes:
     min_alternate_fraction: 0.05 # Reduce for calling variants with lower VAFs
     extra: ""
+
+# If activated preprocessed alignment properties can be applied to each sample individually.
+# paths to the alignment properties json-files need to be set in a tsv-file containing a property name and path.
+# alignment properties will be derived from a customizable column in the sample sheet.
+# if not property name is set for a sample the alignment properties will be estimated best on the samples mapping
+custom_alignment_properties:
+  activate: false
+  column: "panel"
+  tsv: "config_alignment_properties.tsv"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -284,10 +284,10 @@ params:
     extra: ""
 
 # If activated preprocessed alignment properties can be applied to each sample individually.
-# paths to the alignment properties json-files need to be set in a tsv-file containing a property name and path.
-# alignment properties will be derived from a customizable column in the sample sheet.
-# if not property name is set for a sample the alignment properties will be estimated best on the samples mapping
+# Paths to the alignment properties json-files need to be set in a tsv-file containing a property name and path.
+# Alignment properties will be derived from a customizable column in the sample sheet.
+# If not property name is set for a sample the alignment properties will be estimated best on the samples mapping.
 custom_alignment_properties:
   activate: false
   column: "panel"
-  tsv: "config_alignment_properties.tsv"
+  tsv: "config/alignment_properties.tsv"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -286,9 +286,9 @@ params:
     extra: ""
 
 # If activated preprocessed alignment properties can be applied to each sample individually.
-# Paths to the alignment properties json-files need to be set in a tsv-file containing a property name and path.
-# Alignment properties will be derived from a customizable column in the sample sheet.
-# If not property name is set for a sample the alignment properties will be estimated best on the samples mapping.
+# Paths to the alignment properties json files need to be set in a tsv file containing a property name and path.
+# Alignment properties names will be taken from a customizable column in the sample sheet.
+# If no property name is set for a sample or custom_alignment_properties is deactivated the alignment properties will be estimated estimated on the sample's read alignments.
 custom_alignment_properties:
   activate: false
   column: "panel"

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -47,7 +47,7 @@ rule varlociraptor_preprocess:
         candidates=get_candidate_calls,
         bam="results/recal/{sample}.bam",
         bai="results/recal/{sample}.bai",
-        alignment_props="results/alignment-properties/{group}/{sample}.json",
+        alignment_props=get_alignment_props(),
     output:
         "results/observations/{group}/{sample}.{caller}.{scatteritem}.bcf",
     params:

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -47,7 +47,7 @@ rule varlociraptor_preprocess:
         candidates=get_candidate_calls,
         bam="results/recal/{sample}.bam",
         bai="results/recal/{sample}.bai",
-        alignment_props=get_alignment_props(),
+        alignment_props=get_alignment_props,
     output:
         "results/observations/{group}/{sample}.{caller}.{scatteritem}.bcf",
     params:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1609,15 +1609,12 @@ def get_delly_excluded_regions():
         return []
 
 
-def get_alignment_props():
-    def inner(wildcards):
-        if is_activated("custom_alignment_properties"):
-            alignment_prop_column = config["custom_alignment_properties"]["column"]
-            prop_name = extract_unique_sample_column_value(
-                wildcards.sample, alignment_prop_column
-            )
-            if pd.notna(prop_name):
-                return custom_alignment_props.loc[prop_name, "path"]
-        return "results/alignment-properties/{group}/{sample}.json"
-
-    return inner
+def get_alignment_props(wildcards):
+    if is_activated("custom_alignment_properties"):
+        alignment_prop_column = config["custom_alignment_properties"]["column"]
+        prop_name = extract_unique_sample_column_value(
+            wildcards.sample, alignment_prop_column
+        )
+        if pd.notna(prop_name):
+            return custom_alignment_props.loc[prop_name, "path"]
+    return f"results/alignment-properties/{wildcards.group}/{wildcards.sample}.json"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1616,7 +1616,6 @@ def get_alignment_props():
             prop_name = extract_unique_sample_column_value(
                 wildcards.sample, alignment_prop_column
             )
-            print(prop_name)
             if pd.notna(prop_name):
                 return custom_alignment_props.loc[prop_name, "path"]
         return "results/alignment-properties/{group}/{sample}.json"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -111,6 +111,14 @@ primer_panels = (
     else None
 )
 
+
+def is_activated(xpath):
+    c = config
+    for entry in xpath.split("/"):
+        c = c.get(entry, {})
+    return bool(c.get("activate", False))
+
+
 custom_alignment_props = (
     (
         pd.read_csv(
@@ -122,7 +130,7 @@ custom_alignment_props = (
         .set_index(["name"], drop=False)
         .sort_index()
     )
-    if config["custom_alignment_properties"].get("tsv", "")
+    if is_activated("custom_alignment_properties")
     else None
 )
 
@@ -619,13 +627,6 @@ def get_all_group_observations(wildcards):
         group=wildcards.group,
         sample=get_group_samples(wildcards.group),
     )
-
-
-def is_activated(xpath):
-    c = config
-    for entry in xpath.split("/"):
-        c = c.get(entry, {})
-    return bool(c.get("activate", False))
 
 
 def get_star_read_group(wildcards):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -111,6 +111,21 @@ primer_panels = (
     else None
 )
 
+custom_alignment_props = (
+    (
+        pd.read_csv(
+            config["custom_alignment_properties"]["tsv"],
+            sep="\t",
+            dtype={"name": str, "path": str},
+            comment="#",
+        )
+        .set_index(["name"], drop=False)
+        .sort_index()
+    )
+    if config["custom_alignment_properties"].get("tsv", "")
+    else None
+)
+
 
 def get_calling_events(calling_type):
     events = [
@@ -1591,3 +1606,18 @@ def get_delly_excluded_regions():
         )
     else:
         return []
+
+
+def get_alignment_props():
+    def inner(wildcards):
+        if is_activated("custom_alignment_properties"):
+            alignment_prop_column = config["custom_alignment_properties"]["column"]
+            prop_name = extract_unique_sample_column_value(
+                wildcards.sample, alignment_prop_column
+            )
+            print(prop_name)
+            if pd.notna(prop_name):
+                return custom_alignment_props.loc[prop_name, "path"]
+        return "results/alignment-properties/{group}/{sample}.json"
+
+    return inner

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -15,8 +15,6 @@ rule map_reads_bwa:
         "v3.8.0/bio/bwa/mem"
 
 
-# Create distance and minimizer index before mapping
-# Otherwise it will be performed on the first execution leading to race conditions for multiple samples
 rule map_reads_vg:
     input:
         reads=get_map_reads_input,
@@ -31,7 +29,7 @@ rule map_reads_vg:
         extra="",
         sorting="fgbio",
         sort_order="queryname",
-    threads: 8
+    threads: 64
     wrapper:
         "v5.3.0/bio/vg/giraffe"
 

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -150,11 +150,12 @@ rule get_vep_plugins:
 
 rule get_pangenome_haplotypes:
     output:
-        temp(f"{pangenome_prefix}.vcf.gz"),
+        f"{pangenome_prefix}.vcf.gz",
     params:
         url=config["ref"]["pangenome"]["vcf"],
     log:
         "logs/pangenome/haplotypes.log",
+    cache: "omit-software"
     shell:
         "curl -o {output} {params.url} 2> {log}"
 
@@ -163,11 +164,12 @@ rule rename_haplotype_contigs:
     input:
         f"{pangenome_prefix}.vcf.gz",
     output:
-        temp("resources/haplotype_contigs_renamed.tsv"),
+        "resources/haplotype_contigs_renamed.tsv",
     params:
         expressions=config["ref"]["pangenome"].get("rename_expressions", []),
     log:
         "logs/pangenome/chrom_replacement.log",
+    cache: "omit-software"
     conda:
         "../envs/pysam.yaml"
     script:
@@ -179,9 +181,10 @@ rule rename_haplotype_chroms:
         vcf="resources/{pangenome}.vcf.gz",
         tsv="resources/haplotype_contigs_renamed.tsv",
     output:
-        temp("resources/{pangenome}.renamed.vcf.gz"),
+        "resources/{pangenome}.renamed.vcf.gz",
     log:
         "logs/pangenome/{pangenome}_renamed.log",
+    cache: "omit-software"
     conda:
         "../envs/bcftools.yaml"
     shell:

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -347,6 +347,17 @@ properties:
       - freebayes
       - varlociraptor
 
+  custom_alignment_properties:
+    type: object
+    properties:
+      activate:
+        type: boolean
+      column:
+        type: string
+      tsv:
+        type: string
+
+
 required:
   - samples
   - units
@@ -355,3 +366,4 @@ required:
   - calling
   - params
   - annotations
+  - custom_alignment_properties


### PR DESCRIPTION
This PR introduces the definition of custom alignment properties estimated by varlociraptor.
In case custom alignment properties are enabled in the config file property names can be assigned to samples in the samplesheet via a user-defined column. The corresponding alignment properties will be looked up from a tsv sheet containing property names and paths to json-files. In case some sample does not contain a property name (cell entry is NaN) the alignment properties will be estimate by varlociraptor for that sample. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration Updates**
	- Added new `custom_alignment_properties` section to multiple configuration files
	- New configuration option allows custom alignment property settings
	- Default setting: feature disabled, column set to "panel"

- **Schema Updates**
	- Updated configuration schema to include new `custom_alignment_properties` object
	- Made new configuration section mandatory

- **Workflow Enhancements**
	- Introduced dynamic alignment properties retrieval
	- Added functions to check feature activation and get alignment properties
<!-- end of auto-generated comment: release notes by coderabbit.ai -->