### PR TITLE
fix: update wrapper versions to fix yte template bug

### DIFF
--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -103,7 +103,7 @@ rule datavzrd_variants_calls:
             dpath="calling/fdr-control/events/{event}/desc", within=config
         ),
     wrapper:
-        "v5.1.0/utils/datavzrd"
+        "v5.5.0/utils/datavzrd"
 
 
 rule datavzrd_fusion_calls:
@@ -141,7 +141,7 @@ rule datavzrd_fusion_calls:
         groups=get_report_batch("fusions"),
         samples=samples,
     wrapper:
-        "v5.1.0/utils/datavzrd"
+        "v5.5.0/utils/datavzrd"
 
 
 rule bedtools_merge:
@@ -195,4 +195,4 @@ rule datavzrd_coverage:
     params:
         samples=lambda wc: get_group_samples(wc.group),
     wrapper:
-        "v5.1.0/utils/datavzrd"
+        "v5.5.0/utils/datavzrd"


### PR DESCRIPTION
An update of datavzrd wrappers will use a newer YTE version in which a bug related to parsing certain numpy data types is fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated utility wrapper version from v5.1.0 to v5.5.0 for multiple data visualization rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->