### PR TITLE
fix: fix datavzrd template for likely pathogenic interpretation

### DIFF
--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -191,7 +191,7 @@ views:
         ?f"""
         Variants in coding regions.\n{params.event_desc}\n
         SpliceAI scores are probabilities of a variant being splice-altering.\n
-        AlphaMissense scores are classified as: likely benign (<0.34), ambiguous (0.34<=, <=0.564), likely pathogenic (<0.564).
+        AlphaMissense scores are classified as: likely benign (<0.34), ambiguous (0.34<=, <=0.564), likely pathogenic (>0.564).
         """
       dataset: ?f"{group}-coding"
       render-table:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated AlphaMissense score classification description to clarify pathogenicity threshold (>0.564 instead of <0.564)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->