### PR TITLE
fix: sort order of marked duplicates

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -470,11 +470,11 @@ def get_consensus_input(wildcards, bai=False):
 
 def get_trimming_input(wildcards, bai=False):
     ext = "bai" if bai else "bam"
+    aligner = get_aligner(wildcards)
+    ext = f"sorted.{ext}" if aligner == "vg" else ext
     if is_activated("remove_duplicates"):
-        ext = "sorted." + ext if get_aligner(wildcards) == "vg" else ext
         return "results/dedup/{{sample}}.{ext}".format(ext=ext)
     else:
-        aligner = get_aligner(wildcards)
         return "results/mapped/{aligner}/{{sample}}.{ext}".format(
             aligner=aligner, ext=ext
         )

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -471,6 +471,7 @@ def get_consensus_input(wildcards, bai=False):
 def get_trimming_input(wildcards, bai=False):
     ext = "bai" if bai else "bam"
     if is_activated("remove_duplicates"):
+        ext = "sorted." + ext if get_aligner(wildcards) == "vg" else ext
         return "results/dedup/{{sample}}.{ext}".format(ext=ext)
     else:
         aligner = get_aligner(wildcards)

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -29,7 +29,7 @@ rule map_reads_vg:
         extra="",
         sorting="fgbio",
         sort_order="queryname",
-    threads: 64
+    threads: 60
     wrapper:
         "v5.3.0/bio/vg/giraffe"
 
@@ -134,6 +134,18 @@ rule mark_duplicates:
         mem_mb=3000,
     wrapper:
         "v2.5.0/bio/picard/markduplicates"
+
+
+rule sort_duplicates:
+    input:
+        "results/dedup/{sample}.bam",
+    output:
+        temp("results/dedup/{sample}.sorted.bam"),
+    log:
+        "logs/samtools_sort/{sample}.log",
+    threads: 8
+    wrapper:
+        "v5.5.0/bio/samtools/sort"
 
 
 rule calc_consensus_reads:

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -29,7 +29,7 @@ rule map_reads_vg:
         extra="",
         sorting="fgbio",
         sort_order="queryname",
-    threads: 60
+    threads: 64
     wrapper:
         "v5.3.0/bio/vg/giraffe"
 


### PR DESCRIPTION
In case a sample does not have any primers the workflow will fail for reads mapped by vg.
This happens as vg outputs queryname sorted reads required for some post processing steps.
To fix this coordinate sorting needs to be performed before performing base quality recalibration. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new rule to sort BAM files after deduplication.

- **Performance Improvements**
  - Reduced thread allocation for VG read mapping from 64 to 60 threads.

- **Bug Fixes**
  - Updated file extension handling for VG aligner input processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->