### PR TITLE
fix: generalize sorting for pangenome mapped reads

### DIFF
--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -138,11 +138,11 @@ rule mark_duplicates:
 
 rule sort_duplicates:
     input:
-        "results/dedup/{sample}.bam",
+        "results/{subdir}/{sample}.bam",
     output:
-        temp("results/dedup/{sample}.sorted.bam"),
+        temp("results/{subdir}/{sample}.sorted.bam"),
     log:
-        "logs/samtools_sort/{sample}.log",
+        "logs/samtools_sort/{subdir}_{sample}.log",
     threads: 8
     wrapper:
         "v5.5.0/bio/samtools/sort"

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -136,7 +136,7 @@ rule mark_duplicates:
         "v2.5.0/bio/picard/markduplicates"
 
 
-rule sort_duplicates:
+rule sort_vg_reads:
     input:
         "results/{subdir}/{sample}.bam",
     output:


### PR DESCRIPTION
In the previous PR sorting for reads mapped by vg was introduced.
Those changes did not fully consider sorting of reads without duplicates.
This is now reflected by generalizing and renaming the `sort_duplicates` rule.