### PR TITLE
fix: fix annotation of mutational signatures

### DIFF
--- a/workflow/scripts/annotate_mutational_signatures.R
+++ b/workflow/scripts/annotate_mutational_signatures.R
@@ -12,7 +12,11 @@ cosmic_signatures <-  as.matrix(cosmic_signatures
                                 %>% column_to_rownames(var = "Type")
                     )
 
-sample_substitutions <- read_tsv(snakemake@input[[2]])
+# Add a Prefix to sample names for correct handling of numerical group names
+sample_substitutions <- (
+    read_tsv(snakemake@input[[2]])
+    %>% mutate(Sample = paste0("X_", Sample))
+    )
 if (nrow(sample_substitutions) == 0) {
     for (output_file in snakemake@output) {
         write_tsv(tibble(), output_file)
@@ -41,7 +45,7 @@ if (nrow(sample_substitutions) == 0) {
                 as.data.frame(siglasso(spectrum, cosmic_signatures, prior=prior, plot=FALSE)) 
                 %>% rownames_to_column(var="Signature")
                 %>% replace_dots()
-                %>% filter(!!sym(snakemake@wildcards[["group"]]) > 0)
+                %>% filter(!!sym(paste0("X_", snakemake@wildcards[["group"]])) > 0)
                 %>% add_column(Frequency = min_vaf)
             )
             write_tsv(sample_signatures, output_file, col_names=FALSE)


### PR DESCRIPTION
Annotation of mutational signatures will fail in case the sample group is only a numerical value.
In that case R automatically adds a prefix to the column name causing a key error when accessing it.
To fix this a prefix will always be added to the group name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved sample name handling in data processing workflow
	- Fixed group filtering mechanism for mutational signatures analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->