### PR TITLE
feat!: download pangenome indexes from HPRC

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -29,11 +29,7 @@ ref:
     # if active, reads will be aligned to given pangenome instead of to the linear reference genome
     # Important: this is only supported for homo_sapiens so far
     activate: true
-    # URL to pangenome haplotypes (vcf-file)
-    # Graph resources v1.1: https://github.com/human-pangenomics/hpp_pangenome_resources/
-    # Graph resources v1.0: https://github.com/human-pangenomics/hpp_pangenome_resources/blob/main/hprc-v1.0-mc.md
-    # Important: ensure that the haplotype vcf is built against the same reference genome as specified above under build
-    vcf: https://s3-us-west-2.amazonaws.com/human-pangenomics/pangenomes/freeze/freeze1/minigraph-cactus/hprc-v1.1-mc-grch38/hprc-v1.1-mc-grch38.raw.vcf.gz
+    release: "1.1"
     # optional: In case contigs of the hoplotype vcf need to be renamed
     # a list of python expressions can be defined.
     # Contigs can be accessed by `contig`.


### PR DESCRIPTION
Building them on the fly from VCF is lossy.

pangenome/release: 1.1 in combination with ref/release: 111 should result in downloading https://s3-us-west-2.amazonaws.com/human-pangenomics/pangenomes/freeze/freeze1/minigraph-cactus/hprc-v1.1-mc-grch38/hprc-v1.1-mc-grch38.gbz and the other index files for vg, see https://github.com/human-pangenomics/hpp_pangenome_resources.