### PR TITLE
fix: avoid mis-parsing `NA` reference (`REF`) alleles in `split-call-tables.py`

### DIFF
--- a/workflow/scripts/split-call-tables.py
+++ b/workflow/scripts/split-call-tables.py
@@ -227,10 +227,13 @@ def select_spliceai_effect(calls):
 calls = pd.read_csv(
     snakemake.input[0],
     sep="\t",
-    #The default pandas `NaN` value `NA` is a valid REF allele that we have seen in the
-    # wild, so we have to protect against mis-parsing things as `nan` here. Also, vembrane
-    # as the tool producing the input should encode actual `NA` as empty column entries.
+    # The default pandas `NaN` value `NA` is a valid REF allele that we have seen
+    # in the wild, so we have to protect against mis-parsing things as `nan` here.
     keep_default_na=False,
+    # Also, vembrane table as the tool producing the input seems to encode actual
+    # `NA` values as empty column entries or `None` values, based on tests. So only
+    # the empty string and `None` should be considered here.
+    na_values=["", "None"]
 )
 calls["clinical significance"] = (
     calls["clinical significance"]

--- a/workflow/scripts/split-call-tables.py
+++ b/workflow/scripts/split-call-tables.py
@@ -224,7 +224,14 @@ def select_spliceai_effect(calls):
     return calls
 
 
-calls = pd.read_csv(snakemake.input[0], sep="\t")
+calls = pd.read_csv(
+    snakemake.input[0],
+    sep="\t",
+    #The default pandas `NaN` value `NA` is a valid REF allele that we have seen in the
+    # wild, so we have to protect against mis-parsing things as `nan` here. Also, vembrane
+    # as the tool producing the input should encode actual `NA` as empty column entries.
+    keep_default_na=False,
+)
 calls["clinical significance"] = (
     calls["clinical significance"]
     .apply(eval)


### PR DESCRIPTION
pandas `read_csv` has a bunch of default values it parses into `NaN` automatically, among them `NA`:
https://pandas.pydata.org/pandas-docs/version/2.1/reference/api/pandas.read_csv.html#pandas.read_csv

But in our context, this can be a valid reference allele (`REF`) with an unknown nucleotide in the reference sequence at the first position. So we don't want this parsing. Also, `vembrane table` prints missing values as empty column entries, so the empty string should probably be the only automatic parsing to `NaN`.