### PR TITLE
feat: enable event reports

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -169,7 +169,7 @@ def get_final_output(wildcards):
                 if lookup(
                     dpath=f"calling/fdr-control/events/{event}/report",
                     within=config,
-                    default=False,
+                    default=True,
                 ):
                     final_output.extend(
                         expand(


### PR DESCRIPTION
Currently the workflow does not create any reports when reports are enabled in the config.
This happens as we have a global option for creating reports by checking `config["report"]["activate"]`.
Still, when enabling this option no report will be created as for every single event the workflow checks if it contains a report property and defaults to `False` if non exists.
This is misleading as the global option indicates that reports will be created while it is currently opt-in instead of opt-out for every single event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the handling of missing configuration settings so that, when expected data isn’t provided, the system now produces a more complete and consistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->