### PR TITLE
feat: allow retaining of artifacts

### DIFF
--- a/workflow/envs/varlociraptor.yaml
+++ b/workflow/envs/varlociraptor.yaml
@@ -3,6 +3,6 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - varlociraptor =8.6.0
+  - varlociraptor =8.7.0
   - vega-lite-cli =5.16
   - bcftools =1.21

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -849,7 +849,7 @@ def get_fdr_control_params(wildcards):
         dpath="retain-artifacts",
         within=query,
         default=lookup(
-            dpath="calling/fdr-control/retain-artifacts", within=config, default="False"
+            dpath="calling/fdr-control/retain-artifacts", within=config, default=False
         ),
     )
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -845,10 +845,21 @@ def get_fdr_control_params(wildcards):
 
     mode = f"--mode {mode}"
 
+    retain_artifacts = lookup(
+        dpath="retain-artifacts",
+        within=query,
+        default=lookup(
+            dpath="calling/fdr-control/retain-artifacts", within=config, default="False"
+        ),
+    )
+
+    retain_artifacts = "--smart-retain-artifacts" if retain_artifacts else ""
+
     return {
         "threshold": threshold,
         "events": events,
         "mode": mode,
+        "retain_artifacts": retain_artifacts,
         "local": local,
         "filter": query.get("filter"),
     }

--- a/workflow/rules/filtering.smk
+++ b/workflow/rules/filtering.smk
@@ -78,7 +78,7 @@ rule control_fdr:
         "../envs/varlociraptor.yaml"
     shell:
         "varlociraptor filter-calls control-fdr {input} {params.query[mode]} --var {wildcards.vartype} "
-        "--events {params.query[events]} --fdr {params.query[threshold]} > {output} 2> {log}"
+        "--events {params.query[events]} --fdr {params.query[threshold]} {params.query[retain_artifacts]} > {output} 2> {log}"
 
 
 rule merge_calls:


### PR DESCRIPTION
Implementation of retaining artifacts introduced with varlociraptor 8.7.0.
This continues the previous [PR](https://github.com/snakemake-workflows/dna-seq-varlociraptor/pull/365) I merged too early.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an option to enable or disable artifact retention during the filtering process, giving users greater control over processing outcomes.

- **Chores**
  - Upgraded the `varlociraptor` dependency to version 8.7.0 for improved performance and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->