### PR TITLE
perf: Update to datavzrd 2.57.0

### DIFF
--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -103,7 +103,7 @@ rule datavzrd_variants_calls:
             dpath="calling/fdr-control/events/{event}/desc", within=config
         ),
     wrapper:
-        "v5.6.1/utils/datavzrd"
+        "v6.2.0/utils/datavzrd"
 
 
 rule datavzrd_fusion_calls:
@@ -141,7 +141,7 @@ rule datavzrd_fusion_calls:
         groups=get_report_batch("fusions"),
         samples=samples,
     wrapper:
-        "v5.6.1/utils/datavzrd"
+        "v6.2.0/utils/datavzrd"
 
 
 rule bedtools_merge:
@@ -195,4 +195,4 @@ rule datavzrd_coverage:
     params:
         samples=lambda wc: get_group_samples(wc.group),
     wrapper:
-        "v5.6.1/utils/datavzrd"
+        "v6.2.0/utils/datavzrd"


### PR DESCRIPTION
Just a quick PR to use the latest datavzrd version `2.57.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the datavzrd reporting components to use a newer version, ensuring compatibility with the latest features and improvements. No changes to functionality or user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->