### PR TITLE
feat!: fix handling of querysorted reads, replaced cutadapt by fastp, additional performance improvements and tool updates

### DIFF
--- a/.test/config-chm-eval/config.yaml
+++ b/.test/config-chm-eval/config.yaml
@@ -142,7 +142,7 @@ annotations:
 
 
 params:
-  cutadapt: ""
+  fastp: ""
   picard:
     MarkDuplicates: "--VALIDATION_STRINGENCY lenient"
   gatk:

--- a/.test/config-giab/config.yaml
+++ b/.test/config-giab/config.yaml
@@ -136,7 +136,7 @@ annotations:
       plugins: []
 
 params:
-  cutadapt: ""
+  fastp: ""
   picard:
     MarkDuplicates: "--VALIDATION_STRINGENCY LENIENT"
   gatk:

--- a/.test/config-no-candidate-filtering/config.yaml
+++ b/.test/config-no-candidate-filtering/config.yaml
@@ -92,7 +92,7 @@ annotations:
 
 
 params:
-  cutadapt: ""
+  fastp: ""
   picard:
     MarkDuplicates: ""
   gatk:

--- a/.test/config-simple/config.yaml
+++ b/.test/config-simple/config.yaml
@@ -81,7 +81,7 @@ annotations:
 
 
 params:
-  cutadapt: ""
+  fastp: ""
   picard:
     MarkDuplicates: "--VALIDATION_STRINGENCY LENIENT"
   gatk:

--- a/.test/config-sra/config.yaml
+++ b/.test/config-sra/config.yaml
@@ -75,7 +75,7 @@ annotations:
       plugins: []
 
 params:
-  cutadapt: ""
+  fastp: ""
   picard:
     MarkDuplicates: ""
   gatk:

--- a/.test/config-target-regions/config.yaml
+++ b/.test/config-target-regions/config.yaml
@@ -83,7 +83,7 @@ annotations:
 
 
 params:
-  cutadapt: ""
+  fastp: ""
   picard:
     MarkDuplicates: ""
   gatk:

--- a/.test/config-target-regions/config_multiple_beds.yaml
+++ b/.test/config-target-regions/config_multiple_beds.yaml
@@ -85,7 +85,7 @@ annotations:
 
 
 params:
-  cutadapt: ""
+  fastp: ""
   picard:
     MarkDuplicates: ""
   gatk:

--- a/.test/config_primers/config.yaml
+++ b/.test/config_primers/config.yaml
@@ -78,7 +78,7 @@ annotations:
 
 
 params:
-  cutadapt: ""
+  fastp: ""
   picard:
     MarkDuplicates: ""
   gatk:

--- a/config/README.md
+++ b/config/README.md
@@ -28,7 +28,7 @@ For each sample, add one or more sequencing units (runs, lanes or replicates) to
   * `sra` only: specify an SRA (sequence read archive) accession (starting with e.g. ERR or SRR). The pipeline will automatically download the corresponding paired end reads from SRA.
   * If both local files (`fq1`, `fq2`) and SRA accession (`sra`) are available, the local files will be used.
 * Define adapters in the `adapters` column, by putting [fastp arguments](https://github.com/OpenGene/fastp?tab=readme-ov-file#adapters) in quotation marks (e.g. `"--adapter_sequence ACGCGATCG --adapter_sequence_r2 GCTAGCGTACT"`).
-Automatic adapter trimming can be enabled by setting the keyword `auto_trim` (Please consider the fastp documentation for paired end auto trimming). If the column is empty no trimming will be performed.
+Automatic adapter trimming can be enabled by setting the keyword `auto_trim` (Please consider the [fastp documentation](https://github.com/OpenGene/fastp) for flags to put here instead configure the automatic trimming behavior more explicitly). If the column is empty no trimming will be performed.
 
 Missing values can be specified by empty columns or by writing `NA`. Lines can be commented out with `#`.
 

--- a/config/README.md
+++ b/config/README.md
@@ -27,7 +27,8 @@ For each sample, add one or more sequencing units (runs, lanes or replicates) to
   * `fq1` and `fq2` for paired end reads. These can point to any FASTQ files on your system
   * `sra` only: specify an SRA (sequence read archive) accession (starting with e.g. ERR or SRR). The pipeline will automatically download the corresponding paired end reads from SRA.
   * If both local files (`fq1`, `fq2`) and SRA accession (`sra`) are available, the local files will be used.
-* Define adapters in the `adapters` column, by putting [cutadapt arguments](https://cutadapt.readthedocs.org) in quotation marks (e.g. `"-a ACGCGATCG -A GCTAGCGTACT"`).
+* Define adapters in the `adapters` column, by putting [fastp arguments](https://github.com/OpenGene/fastp?tab=readme-ov-file#adapters) in quotation marks (e.g. `"--adapter_sequence ACGCGATCG --adapter_sequence_r2 GCTAGCGTACT"`).
+Automatic adapter trimming can be enabled by setting the keyword `auto_trim` (Please consider the fastp documentation for paired end auto trimming). If the column is empty no trimming will be performed.
 
 Missing values can be specified by empty columns or by writing `NA`. Lines can be commented out with `#`.
 
@@ -57,7 +58,5 @@ For annotating UMIs two additional columns in `sample.tsv` must be set:
   * `fq1` if the UMIs are part of read 1
   * `fq2` if the UMIs are part of read 2
   * `both` if there are UMIs in both paired end reads
-  * the path to an additional fastq file containing just the UMI of each fragment in fq1 and fq2 (with the same read names)
-* `umi_read_structure`: A read structure defining the UMI position in each UMI record (see https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures). If `both` reads contain a UMI, specify a read structure for both with whitespace in between (for example, `8M142T 8M142T`). In case a separate fastq file only containg UMI sequences is set the read structure needs to be `+M`.
-Read names of UMI records must match the corresponding records of the sample fastqs.
+* `umi_len`: Number of bases (UMI length) to be annotated as UMI.
 

--- a/config/README.md
+++ b/config/README.md
@@ -28,7 +28,7 @@ For each sample, add one or more sequencing units (runs, lanes or replicates) to
   * `sra` only: specify an SRA (sequence read archive) accession (starting with e.g. ERR or SRR). The pipeline will automatically download the corresponding paired end reads from SRA.
   * If both local files (`fq1`, `fq2`) and SRA accession (`sra`) are available, the local files will be used.
 * Define adapters in the `adapters` column, by putting [fastp arguments](https://github.com/OpenGene/fastp?tab=readme-ov-file#adapters) in quotation marks (e.g. `"--adapter_sequence ACGCGATCG --adapter_sequence_r2 GCTAGCGTACT"`).
-Automatic adapter trimming can be enabled by setting the keyword `auto_trim` (Please consider the [fastp documentation](https://github.com/OpenGene/fastp) for flags to put here instead configure the automatic trimming behavior more explicitly). If the column is empty no trimming will be performed.
+Automatic adapter trimming can be enabled by setting the keyword `auto_trim` (Please consider the [fastp documentation](https://github.com/OpenGene/fastp) for flags to put here to configure the automatic trimming behavior more explicitly). If the column is empty no trimming will be performed.
 
 Missing values can be specified by empty columns or by writing `NA`. Lines can be commented out with `#`.
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -261,7 +261,7 @@ tables:
   generate_excel: true
 
 params:
-  cutadapt: ""
+  fastp: ""
   picard:
     MarkDuplicates: "--VALIDATION_STRINGENCY LENIENT"
   gatk:

--- a/config/samples.tsv
+++ b/config/samples.tsv
@@ -1,2 +1,2 @@
-sample_name	alias	group	platform	purity	panel	umi_read	umi_read_structure	datatype	calling
+sample_name	alias	group	platform	purity	panel	umi_read	umi_len	datatype	calling
 SRR702070	tumor	SRR702070_group	ILLUMINA	1.0				dna	variants

--- a/workflow/envs/umi_tools.yaml
+++ b/workflow/envs/umi_tools.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - umi_tools =1.1.6

--- a/workflow/envs/varlociraptor.yaml
+++ b/workflow/envs/varlociraptor.yaml
@@ -3,6 +3,6 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - varlociraptor =8.7.0
+  - varlociraptor =8.7.3
   - vega-lite-cli =5.16
   - bcftools =1.21

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -35,7 +35,7 @@ rule varlociraptor_alignment_properties:
     conda:
         "../envs/varlociraptor.yaml"
     shell:
-        "varlociraptor estimate alignment-properties {input.ref} --bams {input.bam} > {output} 2> {log}"
+        "/media/HDD/workspace/varlociraptor/target/release/varlociraptor estimate alignment-properties {input.ref} --bams {input.bam} > {output} 2> {log}"
 
 
 rule varlociraptor_preprocess:
@@ -59,7 +59,7 @@ rule varlociraptor_preprocess:
     conda:
         "../envs/varlociraptor.yaml"
     shell:
-        "varlociraptor preprocess variants --candidates {input.candidates} {params.extra} "
+        "/media/HDD/workspace/varlociraptor/target/release/varlociraptor preprocess variants --candidates {input.candidates} {params.extra} "
         "--alignment-properties {input.alignment_props} {input.ref} --bam {input.bam} --output {output} "
         "2> {log}"
 
@@ -89,7 +89,7 @@ rule varlociraptor_call:
     benchmark:
         "benchmarks/varlociraptor/call/{group}.{caller}.{scatteritem}.tsv"
     shell:
-        "(varlociraptor call variants {params.extra} generic --obs {params.obs}"
+        "(/media/HDD/workspace/varlociraptor/target/release/varlociraptor call variants {params.extra} generic --obs {params.obs}"
         " --scenario {input.scenario} {params.postprocess} {output}) 2> {log}"
 
 

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -35,7 +35,7 @@ rule varlociraptor_alignment_properties:
     conda:
         "../envs/varlociraptor.yaml"
     shell:
-        "/media/HDD/workspace/varlociraptor/target/release/varlociraptor estimate alignment-properties {input.ref} --bams {input.bam} > {output} 2> {log}"
+        "varlociraptor estimate alignment-properties {input.ref} --bams {input.bam} > {output} 2> {log}"
 
 
 rule varlociraptor_preprocess:
@@ -59,7 +59,7 @@ rule varlociraptor_preprocess:
     conda:
         "../envs/varlociraptor.yaml"
     shell:
-        "/media/HDD/workspace/varlociraptor/target/release/varlociraptor preprocess variants --candidates {input.candidates} {params.extra} "
+        "varlociraptor preprocess variants --candidates {input.candidates} {params.extra} "
         "--alignment-properties {input.alignment_props} {input.ref} --bam {input.bam} --output {output} "
         "2> {log}"
 
@@ -89,7 +89,7 @@ rule varlociraptor_call:
     benchmark:
         "benchmarks/varlociraptor/call/{group}.{caller}.{scatteritem}.tsv"
     shell:
-        "(/media/HDD/workspace/varlociraptor/target/release/varlociraptor call variants {params.extra} generic --obs {params.obs}"
+        "(varlociraptor call variants {params.extra} generic --obs {params.obs}"
         " --scenario {input.scenario} {params.postprocess} {output}) 2> {log}"
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -653,27 +653,25 @@ def get_map_reads_sorting_params(wildcards, ordering=False):
 
 def get_preprocessed_sorting_input(wildcards):
     if wildcards.aligner == "vg":
-        return "results/mapped/vg/{sample}.bam"
+        return "results/mapped/vg/{sample}.rg.bam"
     else:
         return get_add_readgroup_input(wildcards)
 
 
 def get_add_readgroup_input(wildcards):
-    aligner = get_aligner(wildcards)
     if sample_has_umis(wildcards.sample):
-        return f"results/mapped/{aligner}/{{sample}}.annotated.bam"
+        return "results/mapped/{aligner}/{sample}.annotated.bam"
     else:
         return get_namesort_input(wildcards)
 
 
 def get_namesort_input(wildcards):
-    aligner = get_aligner(wildcards)
-    if aligner == "bwa":
-        return "results/mapped/bwa/{sample}.raw.bam"
+    if wildcards.aligner == "bwa":
+        return "results/mapped/{aligner}/{sample}.raw.bam"
     elif sample_has_primers(wildcards):
-        return "results/mapped/vg/{sample}.mate_fixed.bam"
+        return "results/mapped/{aligner}/{sample}.mate_fixed.bam"
     else:
-        return "results/mapped/vg/{sample}.reheadered.bam"
+        return "results/mapped/{aligner}/{sample}.reheadered.bam"
 
 
 def get_mutational_burden_targets():

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1549,16 +1549,15 @@ def get_fastqc_results(wildcards):
         pattern, unit=sample_units[paired_end_units].itertuples(), fq="fq2"
     )
 
-    # Todo can this be replaced by fastp?
-    # # cutadapt
-    # if sample_units["adapters"].notna().all():
-    #     pattern = "results/trimmed/{unit.sample_name}/{unit.unit_name}.{mode}.qc.txt"
-    #     yield from expand(
-    #         pattern, unit=sample_units[paired_end_units].itertuples(), mode="paired"
-    #     )
-    #     yield from expand(
-    #         pattern, unit=sample_units[~paired_end_units].itertuples(), mode="single"
-    #     )
+    # fastp
+    if sample_units["adapters"].notna().all():
+        pattern = "results/trimmed/{unit.sample_name}/{unit.unit_name}.{mode}.qc.html"
+        yield from expand(
+            pattern, unit=sample_units[paired_end_units].itertuples(), mode="paired"
+        )
+        yield from expand(
+            pattern, unit=sample_units[~paired_end_units].itertuples(), mode="single"
+        )
 
     # samtools idxstats
     yield from expand(

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -371,7 +371,12 @@ def get_fastp_adapters(wildcards):
     try:
         adapters = unit["adapters"]
         if isinstance(adapters, str):
-            return adapters
+            # Autotrimming is enabled by default.
+            # Therefore no adapter parameter needs to be passed.
+            if adapters == "auto_trim":
+                return ""
+            else:
+                return adapters
         return ""
     except KeyError:
         return ""

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -442,10 +442,7 @@ def get_sample_datatype(sample):
 
 def get_markduplicates_input(wildcards):
     aligner = get_aligner(wildcards)
-    if sample_has_umis(wildcards.sample):
-        return f"results/mapped/{aligner}/{{sample}}.annotated.bam"
-    else:
-        return f"results/mapped/{aligner}/{{sample}}.sorted.bam"
+    return f"results/mapped/{aligner}/{{sample}}.sorted.bam"
 
 
 def get_recalibrate_quality_input(wildcards, bai=False):
@@ -655,14 +652,14 @@ def get_map_reads_sorting_params(wildcards, ordering=False):
 
 
 def get_preprocessed_sorting_input(wildcards):
-    aligner = get_aligner(wildcards)
-    if aligner == "vg":
-        return "results/mapped/{vg}/{sample}.bam"
+    if wildcards.aligner == "vg":
+        return "results/mapped/vg/{sample}.bam"
     else:
         return get_add_readgroup_input(wildcards)
 
 
 def get_add_readgroup_input(wildcards):
+    aligner = get_aligner(wildcards)
     if sample_has_umis(wildcards.sample):
         return f"results/mapped/{aligner}/{{sample}}.annotated.bam"
     else:

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -8,8 +8,6 @@ rule map_reads_bwa:
         "logs/bwa_mem/{sample}.log",
     params:
         extra=get_read_group("-R "),
-        #sorting=get_map_reads_sorting_params,
-        #sort_order=lambda wc: get_map_reads_sorting_params(wc, ordering=True),
     threads: 8
     wrapper:
         "v3.8.0/bio/bwa/mem"

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -162,15 +162,16 @@ rule annotate_umis:
         "v3.7.0/bio/fgbio/annotatebamwithumis"
 
 
-# adding read groups is necessary because base recalibration throws errors
+# adding read groups is exclusive to vg mapped reads and
+# necessary because base recalibration throws errors
 # for not being able to find read group information
 rule add_read_group:
     input:
         get_add_readgroup_input,
     output:
-        temp("results/mapped/vg/{sample}.bam"),
+        temp("results/mapped/{aligner}/{sample}.rg.bam"),
     log:
-        "logs/samtools/add_rg/{sample}.log",
+        "logs/samtools/add_rg/{aligner}_{sample}.log",
     params:
         read_group=get_read_group(""),
         compression_threads=lambda wildcards, threads: (

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -75,7 +75,7 @@ rule map_reads_vg:
         sorting="none",
     threads: 64
     wrapper:
-        "v5.7.0/bio/vg/giraffe"
+        "v6.1.0/bio/vg/giraffe"
 
 
 rule reheader_mapped_reads:
@@ -95,7 +95,6 @@ rule reheader_mapped_reads:
         " samtools reheader - {input} > {output}) 2> {log}"
 
 
-# TODO If namesorted needed move this infront
 rule fix_mate:
     input:
         "results/mapped/vg/{sample}.reheadered.bam",
@@ -193,7 +192,7 @@ rule sort_preprocessed_alignments:
     log:
         "logs/sort/{aligner}/{sample}.log",
     params:
-        extra="-n",
+        extra="",
     threads: 16
     resources:
         mem="8GB",

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -8,13 +8,13 @@ rule get_sra:
         "v5.0.2/bio/sra-tools/fasterq-dump"
 
 
-rule cutadapt_pipe:
+rule fastp_pipe:
     input:
-        get_cutadapt_pipe_input,
+        get_fastp_pipe_input,
     output:
-        pipe("pipe/cutadapt/{sample}/{unit}.{fq}.{ext}"),
+        pipe("pipe/fastp/{sample}/{unit}.{fq}.{ext}"),
     log:
-        "logs/pipe-fastqs/catadapt/{sample}-{unit}.{fq}.{ext}.log",
+        "logs/pipe-fastqs/fastp/{sample}-{unit}.{fq}.{ext}.log",
     wildcard_constraints:
         ext=r"fastq|fastq\.gz",
     threads: 0  # this does not need CPU
@@ -22,37 +22,74 @@ rule cutadapt_pipe:
         "cat {input} > {output} 2> {log}"
 
 
-rule cutadapt_pe:
+rule fastp_se:
     input:
-        get_cutadapt_input,
+        sample=lambda wc: get_fastp_input(wc),
     output:
-        fastq1=temp("results/trimmed/{sample}/{unit}_R1.fastq.gz"),
-        fastq2=temp("results/trimmed/{sample}/{unit}_R2.fastq.gz"),
-        qc="results/trimmed/{sample}/{unit}.paired.qc.txt",
+        trimmed=temp("results/trimmed/{sample}/{unit}.single.fastq.gz"),
+        html="results/trimmed/{sample}/{unit}.se.html",
+        json="results/trimmed/{sample}/{unit}.se.json",
     log:
-        "logs/cutadapt/{sample}-{unit}.log",
+        "logs/fastp/se/{sample}_{unit}.log",
     params:
-        extra=config["params"]["cutadapt"],
-        adapters=get_cutadapt_adapters,
-    threads: 8
+        adapters=get_fastp_adapters,
+        extra=get_fastp_extra,
+    threads: 1
     wrapper:
-        "v3.5.3/bio/cutadapt/pe"
+        "v6.2.0/bio/fastp"
 
 
-rule cutadapt_se:
+rule fastp_pe:
     input:
-        get_cutadapt_input,
+        sample=lambda wc: get_fastp_input(wc),
     output:
-        fastq=temp("results/trimmed/{sample}/{unit}.single.fastq.gz"),
-        qc="results/trimmed/{sample}/{unit}.single.qc.txt",
+        trimmed=[
+            temp("results/trimmed/{sample}/{unit}_R1.fastq.gz"),
+            temp("results/trimmed/{sample}/{unit}_R2.fastq.gz"),
+        ],
+        html="results/trimmed/{sample}/{unit}.html",
+        json="results/trimmed/{sample}/{unit}.json",
     log:
-        "logs/cutadapt/{sample}-{unit}.se.log",
+        "logs/fastp/pe/{sample}_{unit}.log",
     params:
-        extra=config["params"]["cutadapt"],
-        adapters=get_cutadapt_adapters,
+        adapters=get_fastp_adapters,
+        extra=get_fastp_extra,
     threads: 8
     wrapper:
-        "v3.5.3/bio/cutadapt/se"
+        "v6.2.0/bio/fastp"
+
+
+# rule cutadapt_pe:
+#     input:
+#         get_cutadapt_input,
+#     output:
+#         fastq1=temp("results/trimmed/{sample}/{unit}_R1.fastq.gz"),
+#         fastq2=temp("results/trimmed/{sample}/{unit}_R2.fastq.gz"),
+#         qc="results/trimmed/{sample}/{unit}.paired.qc.txt",
+#     log:
+#         "logs/cutadapt/{sample}-{unit}.log",
+#     params:
+#         extra=config["params"]["cutadapt"],
+#         adapters=get_cutadapt_adapters,
+#     threads: 8
+#     wrapper:
+#         "v3.5.3/bio/cutadapt/pe"
+
+
+# rule cutadapt_se:
+#     input:
+#         get_cutadapt_input,
+#     output:
+#         fastq=temp("results/trimmed/{sample}/{unit}.single.fastq.gz"),
+#         qc="results/trimmed/{sample}/{unit}.single.qc.txt",
+#     log:
+#         "logs/cutadapt/{sample}-{unit}.se.log",
+#     params:
+#         extra=config["params"]["cutadapt"],
+#         adapters=get_cutadapt_adapters,
+#     threads: 8
+#     wrapper:
+#         "v3.5.3/bio/cutadapt/se"
 
 
 rule merge_trimmed_fastqs:

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -27,14 +27,14 @@ rule fastp_se:
         sample=lambda wc: get_fastp_input(wc),
     output:
         trimmed=temp("results/trimmed/{sample}/{unit}.single.fastq.gz"),
-        html="results/trimmed/{sample}/{unit}.se.html",
-        json="results/trimmed/{sample}/{unit}.se.json",
+        html="results/trimmed/{sample}/{unit}.single.qc.html",
+        json="results/trimmed/{sample}/{unit}.single.json",
     log:
         "logs/fastp/se/{sample}_{unit}.log",
     params:
         adapters=get_fastp_adapters,
         extra=get_fastp_extra,
-    threads: 1
+    threads: 8
     wrapper:
         "v6.2.0/bio/fastp"
 
@@ -47,8 +47,8 @@ rule fastp_pe:
             temp("results/trimmed/{sample}/{unit}_R1.fastq.gz"),
             temp("results/trimmed/{sample}/{unit}_R2.fastq.gz"),
         ],
-        html="results/trimmed/{sample}/{unit}.html",
-        json="results/trimmed/{sample}/{unit}.json",
+        html="results/trimmed/{sample}/{unit}.paired.qc.html",
+        json="results/trimmed/{sample}/{unit}.paired.json",
     log:
         "logs/fastp/pe/{sample}_{unit}.log",
     params:
@@ -57,39 +57,6 @@ rule fastp_pe:
     threads: 8
     wrapper:
         "v6.2.0/bio/fastp"
-
-
-# rule cutadapt_pe:
-#     input:
-#         get_cutadapt_input,
-#     output:
-#         fastq1=temp("results/trimmed/{sample}/{unit}_R1.fastq.gz"),
-#         fastq2=temp("results/trimmed/{sample}/{unit}_R2.fastq.gz"),
-#         qc="results/trimmed/{sample}/{unit}.paired.qc.txt",
-#     log:
-#         "logs/cutadapt/{sample}-{unit}.log",
-#     params:
-#         extra=config["params"]["cutadapt"],
-#         adapters=get_cutadapt_adapters,
-#     threads: 8
-#     wrapper:
-#         "v3.5.3/bio/cutadapt/pe"
-
-
-# rule cutadapt_se:
-#     input:
-#         get_cutadapt_input,
-#     output:
-#         fastq=temp("results/trimmed/{sample}/{unit}.single.fastq.gz"),
-#         qc="results/trimmed/{sample}/{unit}.single.qc.txt",
-#     log:
-#         "logs/cutadapt/{sample}-{unit}.se.log",
-#     params:
-#         extra=config["params"]["cutadapt"],
-#         adapters=get_cutadapt_adapters,
-#     threads: 8
-#     wrapper:
-#         "v3.5.3/bio/cutadapt/se"
 
 
 rule merge_trimmed_fastqs:

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -306,7 +306,7 @@ properties:
   params:
     type: object
     properties:
-      cutadapt:
+      fastp:
         type: string
       gatk:
         type: object
@@ -343,7 +343,7 @@ properties:
     required:
       - gatk
       - picard
-      - cutadapt
+      - fastp
       - freebayes
       - varlociraptor
 

--- a/workflow/schemas/samples.schema.yaml
+++ b/workflow/schemas/samples.schema.yaml
@@ -50,11 +50,11 @@ properties:
     description: ID of primer panel
   umi_read:
     type: string
-    pattern: "(^(fq[1,2]|both)$)|(.(fq|fastq)(.gz)?)$"
+    pattern: "^(fq[1,2]|both)$"
     description: fq1 or fq2 for read containing umis
-  umi_read_structure:
-    type: string
-    description: read structure defining position of UMIs in reads (see https://github.com/fulcrumgenomics/fgbio/wiki/Read-Structures)
+  umi_len:
+    type: number
+    description: length of UMI
 
 required:
   - sample_name
@@ -65,4 +65,4 @@ required:
   - calling
 
 dependentRequired:
-  umi_read: ["umi_read_structure"]
+  umi_read: ["umi_len"]

--- a/workflow/scripts/split-call-tables.py
+++ b/workflow/scripts/split-call-tables.py
@@ -195,7 +195,7 @@ class PopulationDb:
         )
 
     def _load_variants(self):
-        return self.bcf.fetch(str(self.contig), self.pos, self.end)
+        return self.bcf.fetch(str(self.contig), self.pos - 1, self.end)
 
     @property
     def end(self):
@@ -233,7 +233,7 @@ calls = pd.read_csv(
     # Also, vembrane table as the tool producing the input seems to encode actual
     # `NA` values as empty column entries or `None` values, based on tests. So only
     # the empty string and `None` should be considered here.
-    na_values=["", "None"]
+    na_values=["", "None"],
 )
 calls["clinical significance"] = (
     calls["clinical significance"]

--- a/workflow/scripts/split-call-tables.py
+++ b/workflow/scripts/split-call-tables.py
@@ -173,6 +173,7 @@ class PopulationDb:
             self.pos = pos
             self._variants = self._load_variants()
         for variant in self._variants:
+            print(variant.pos)
             if variant.pos == pos and variant.alts[0] == alt:
                 yield variant
             if variant.pos > pos:
@@ -195,6 +196,7 @@ class PopulationDb:
         )
 
     def _load_variants(self):
+        print(self.pos)
         return self.bcf.fetch(str(self.contig), self.pos - 1, self.end)
 
     @property


### PR DESCRIPTION
The latest commit broke UMI annotation as the input bam and fastq files both need to be namesorted.
This was previously done by fgbio but namesorting of bam records got replaced by samtools for performance reasons.
As fgbio and samtools do not create the identical namesorted record order fastqs (still ordered by fgbio) and bams got incompatible causing umi annotation to fail.
The following changes have been applied to fix this:

- replaced cutadapt by fastp: allows UMI annotation during trimming (`fgbio AnnotateBamwithUmis` and queryname sorting of fastq and bams is not necessary anymore fixing the issue with querysorted reads)
- added rule for `umi_tools group`: writes UMI from read name into BX-tag of bam record
-  additional fix: trimmed sequences of zero-length, previously causing `vg giraffe` to fail, will be automatically removed by fastp
- updated varlociraptor to v8.7.3: fixes a bug where reads of length one could cause a floatisnan error

_Attention_: The replacement of cutadapt by fastp introduces a breaking change in the config file and in the way adapters have to be specified in the sample sheet. Further, the column `umi_read_structure` of `samples.tsv` has been renamed to `umi_len` and contains only the UMI length instead of a read template.

additional updates:

- perf: rule fix_mate is only executed if sample has primers
- improvement: update vg to v1.65.0 including some fixes for `vg giraffe`
- fix:  fixed an offset error in split-call-tables.py where not all previously found variants were fetched in the population-db lookup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added support for the "fastp" tool for read trimming and preprocessing.
	- Introduced a new conda environment for "umi_tools" to improve reproducibility.

- **Bug Fixes**
	- Updated workflow rules and configuration schemas to ensure compatibility with "fastp" and the latest versions of related tools.

- **Refactor**
	- Replaced all references to "cutadapt" with "fastp" across configuration files, workflow rules, and schemas.
	- Simplified and streamlined trimming and mapping steps for improved workflow clarity.
	- Removed redundant sorting steps and updated alignment workflows with newer tool versions.
	- Refined UMI handling by updating parameter formats and schema validation.

- **Documentation**
	- Updated configuration and schema files to reflect new parameters and validation rules for "fastp" and UMI handling.
	- Revised sample sheet documentation to explain new adapter trimming options and simplified UMI annotation instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->