### PR TITLE
fix: consider aux files as local (they are part of the config, which is always considered local)

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -919,7 +919,8 @@ def get_annotation_filter_aux(wildcards, input):
 
 def get_annotation_filter_aux_files(wildcards):
     return [
-        path
+        # aux files are considered as part of the config, hence local
+        local(path)
         for filter_name in get_annotation_filter_names(wildcards)
         for name, path in get_filter_aux_entries(filter_name).items()
     ]
@@ -938,16 +939,17 @@ def get_candidate_filter_aux_files():
     if "candidates" not in config["calling"]["filter"]:
         return []
     else:
-        return [path for name, path in get_filter_aux_entries("candidates").items()]
+        # aux files are considered as part of the config, hence local
+        return [local(path) for name, path in get_filter_aux_entries("candidates").items()]
 
 
-def get_candidate_filter_aux():
+def get_candidate_filter_aux(wildcards, input):
     if "candidates" not in config["calling"]["filter"]:
         return ""
     else:
         return [
             f"--aux {name}={path}"
-            for name, path in get_filter_aux_entries("candidates").items()
+            for name, path in zip(get_filter_aux_entries("candidates").keys(), input.aux)
         ]
 
 

--- a/workflow/rules/filtering.smk
+++ b/workflow/rules/filtering.smk
@@ -8,7 +8,7 @@ rule filter_candidates_by_annotation:
         "logs/filter-calls/annotation/{group}.{caller}.{scatteritem}.log",
     params:
         filter=get_candidate_filter_expression,
-        aux=get_candidate_filter_aux(),
+        aux=get_candidate_filter_aux,
     conda:
         "../envs/vembrane.yaml"
     shell:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved handling of auxiliary files for annotation and candidate filters, ensuring consistent treatment as local resources.
  - Adjusted internal logic for pairing auxiliary file keys and paths to enhance reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->