### PR TITLE
feat: add complement events

### DIFF
--- a/.test/config-sra/config.yaml
+++ b/.test/config-sra/config.yaml
@@ -47,7 +47,7 @@ calling:
     moderate: "ANN['IMPACT'] == 'MODERATE'"
     no_filter: "True"
   fdr-control:
-    threshold: 0.05
+    threshold: 0.01
     # Denote FDR control mode.
     # The default (local-smart) is recommended because it provides the most realistic and intuitive results.
     # See see https://varlociraptor.github.io/docs/filtering for details.
@@ -55,36 +55,36 @@ calling:
     # Retain artifacts upon FDR control (i.e. do not remove them from the callset,
     # see https://varlociraptor.github.io/docs/filtering)
     # Only applies in smart mode (local-smart or global-smart).
-    retain-artifacts: false
     events: 
       moderate:
+        desc: Variants with moderate impact
         varlociraptor: 
           - base_only
           - changed_only
           - both
         filter:
           - moderate
-        desc: Variants with moderate impact
       present:
+        desc: All variants present, unfiltered.
         varlociraptor: 
           - base_only
           - changed_only
           - both
         filter:
           - no_filter
-        desc: Variants with moderate impact
       present_or_artifact:
+        desc: All variants present, unfiltered and with the artifacts probability also considered part of the present probability.
+        retain-artifacts: true
         varlociraptor: 
           - base_only
           - changed_only
           - both
-          - artifact
         filter:
           - no_filter
-        desc: Variants with moderate impact
 
 complement_events:
   filtered_artifacts:
+    desc: All variants that were removed from the present event during fdr control due to a high artifacts probability.
     report: True
     types: ["variants", "fusions"]
     full: present_or_artifact

--- a/.test/config-sra/config.yaml
+++ b/.test/config-sra/config.yaml
@@ -55,7 +55,7 @@ calling:
     # Retain artifacts upon FDR control (i.e. do not remove them from the callset,
     # see https://varlociraptor.github.io/docs/filtering)
     # Only applies in smart mode (local-smart or global-smart).
-    retain-artifacts: true
+    retain-artifacts: false
     events: 
       moderate:
         varlociraptor: 

--- a/.test/config-sra/config.yaml
+++ b/.test/config-sra/config.yaml
@@ -105,7 +105,7 @@ annotations:
       params: "--fields IMPACT"
       plugins: []
     final_calls:
-      params: "--fields IMPACT"
+      params: "--everything"
       plugins: []
 
 params:

--- a/.test/config-sra/config.yaml
+++ b/.test/config-sra/config.yaml
@@ -45,11 +45,19 @@ calling:
   filter:
     candidates: "ANN['IMPACT'] in ['MODERATE', 'HIGH']"
     moderate: "ANN['IMPACT'] == 'MODERATE'"
+    no_filter: "True"
   fdr-control:
     threshold: 0.05
-    local: true
+    # Denote FDR control mode.
+    # The default (local-smart) is recommended because it provides the most realistic and intuitive results.
+    # See see https://varlociraptor.github.io/docs/filtering for details.
+    mode: local-smart
+    # Retain artifacts upon FDR control (i.e. do not remove them from the callset,
+    # see https://varlociraptor.github.io/docs/filtering)
+    # Only applies in smart mode (local-smart or global-smart).
+    retain-artifacts: true
     events: 
-      present:
+      moderate:
         varlociraptor: 
           - base_only
           - changed_only
@@ -57,6 +65,32 @@ calling:
         filter:
           - moderate
         desc: Variants with moderate impact
+      present:
+        varlociraptor: 
+          - base_only
+          - changed_only
+          - both
+        filter:
+          - no_filter
+        desc: Variants with moderate impact
+      present_or_artifact:
+        varlociraptor: 
+          - base_only
+          - changed_only
+          - both
+          - artifact
+        filter:
+          - no_filter
+        desc: Variants with moderate impact
+
+complement_events:
+  filtered_artifacts:
+    report: True
+    types: ["variants", "fusions"]
+    full: present_or_artifact
+    remove:
+      - present
+
 
 annotations:
   dbnsfp:

--- a/.test/config-sra/config.yaml
+++ b/.test/config-sra/config.yaml
@@ -132,7 +132,7 @@ gene_coverage:
   min_avg_coverage: 8
 
 report:
-  activate: false
+  activate: true
   max_read_depth: 250
   stratify:
     activate: false

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -150,10 +150,6 @@ calling:
     # The default (local-smart) is recommended because it provides the most realistic and intuitive results.
     # See see https://varlociraptor.github.io/docs/filtering for details.
     mode: local-smart
-    # Retain artifacts upon FDR control (i.e. do not remove them from the callset,
-    # see https://varlociraptor.github.io/docs/filtering)
-    # Only applies in smart mode (local-smart or global-smart).
-    retain-artifacts: false
     events:
       # Add any number of events here to filter for.
       # The id of each event can be chosen freely, but needs to contain
@@ -172,6 +168,10 @@ calling:
         # This will occur in the report.
         desc: |
           Some description.
+        # Retain artifacts upon FDR control (i.e. do not remove them from the callset,
+        # see https://varlociraptor.github.io/docs/filtering)
+        # Only applies in smart mode (local-smart or global-smart).
+        retain-artifacts: false
         varlociraptor:
           # Add varlociraptor events to aggregated over.
           # The probability for the union of these events is used for controlling

--- a/workflow/resources/datavzrd/fusion-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/fusion-calls-template.datavzrd.yaml
@@ -1,6 +1,6 @@
 __use_yte__: true
 
-name: ?f"Fusion calls {wildcards.event}"
+name: ?f"Fusion calls {wildcards.any_event}"
 
 default-view: ?f"{params.groups[0]}-fusions"
 

--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -1,6 +1,6 @@
 __use_yte__: true
 
-name: ?f"Variant calls {wildcards.event}"
+name: ?f"Variant calls {wildcards.any_event}"
 
 default-view: ?"overview" if input.variant_oncoprints else f"{params.groups[0]}-coding"
 max-in-memory-rows: 1500

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1569,7 +1569,7 @@ def get_datavzrd_report_labels(wildcards):
     if "labels" in event:
         labels.update({key: str(value) for key, value in event["labels"].items()})
     else:
-        labels["callset"] = wildcards.event.replace("_", " ")
+        labels["callset"] = wildcards.any_event.replace("_", " ")
     return labels
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -459,7 +459,7 @@ def get_markduplicates_input(wildcards):
 
 def get_merge_exclude_events_input(ext="bcf"):
     def inner(wildcards):
-        events = config['complement_events'][wildcards.complement_event]['remove']
+        events = config["complement_events"][wildcards.complement_event]["remove"]
         return expand(
             "results/final-calls/{g}.{e}.{calling_type}.fdr-controlled.{ext}",
             g=wildcards.group,
@@ -467,7 +467,7 @@ def get_merge_exclude_events_input(ext="bcf"):
             calling_type=wildcards.calling_type,
             ext=ext,
         )
-    
+
     return inner
 
 
@@ -998,14 +998,18 @@ def get_varlociraptor_params(wildcards, params):
         params += " --propagate-info-fields GENE_NAME GENE_ID EXON_NUMBER"
     return params
 
+
 COMPLEMENT_EVENTS = config.get("complement_events", {}).keys()
+
 
 wildcard_constraints:
     group="|".join(groups),
     sample="|".join(samples["sample_name"]),
     caller="|".join(["freebayes", "delly", "arriba"]),
     filter="|".join(config["calling"]["filter"]),
-    event="|".join(config["calling"]["fdr-control"]["events"].keys() ^ COMPLEMENT_EVENTS),
+    event="|".join(
+        config["calling"]["fdr-control"]["events"].keys() ^ COMPLEMENT_EVENTS
+    ),
     complement_event="|".join(COMPLEMENT_EVENTS),
     regions_type="|".join(["expanded", "covered"]),
     calling_type="|".join(["fusions", "variants"]),
@@ -1504,7 +1508,7 @@ def get_primer_extra(wc, input):
     min_primer_len = get_shortest_primer_length(input.reads)
     # Check if shortest primer is below default values
     if min_primer_len < 32:
-        extra += f" -T {min_primer_len - 2}"
+        extra += f" -T {min_primer_len-2}"
     if min_primer_len < 19:
         extra += f" -k {min_primer_len}"
     return extra

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1526,7 +1526,7 @@ def get_datavzrd_data(impact="coding"):
         return expand(
             pattern,
             impact=impact,
-            event=wildcards.any_event,
+            any_event=wildcards.any_event,
             group=get_report_batch(calling_type),
         )
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1555,11 +1555,13 @@ def get_variant_oncoprint_tables(wildcards, input):
     else:
         return []
 
+
 def get_any_event(wildcards):
     if wildcards.any_event in COMPLEMENT_EVENTS:
         return config["complement_events"][wildcards.any_event]
     else:
         return config["calling"]["fdr-control"]["events"][wildcards.any_event]
+
 
 def get_datavzrd_report_labels(wildcards):
     event = get_any_event(wildcards)

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -7,9 +7,19 @@ rule split_call_tables:
         coding="results/tables/{group}.{any_event}.coding.fdr-controlled.tsv",
         noncoding="results/tables/{group}.{any_event}.noncoding.fdr-controlled.tsv",
     params:
-        sorting=lambda wc:
-            lookup(within=config, dpath="complement_events/{wc.any_event}/sort", default=list()) if wc.any_event in COMPLEMENT_EVENTS else
-            lookup(within=config, dpath="calling/fdr-control/events/{wc.any_event}/sort", default=list()),
+        sorting=lambda wc: (
+            lookup(
+                within=config,
+                dpath="complement_events/{wc.any_event}/sort",
+                default=list(),
+            )
+            if wc.any_event in COMPLEMENT_EVENTS
+            else lookup(
+                within=config,
+                dpath="calling/fdr-control/events/{wc.any_event}/sort",
+                default=list(),
+            )
+        ),
     log:
         "logs/split_tables/{group}.{any_event}.log",
     conda:

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -1,17 +1,17 @@
 rule split_call_tables:
     input:
-        calls="results/tables/{group}.{event}.variants.fdr-controlled.tsv",
+        calls="results/tables/{group}.{any_event}.variants.fdr-controlled.tsv",
         population_db=get_cleaned_population_db(),
         population_db_idx=get_cleaned_population_db(idx=True),
     output:
-        coding="results/tables/{group}.{event}.coding.fdr-controlled.tsv",
-        noncoding="results/tables/{group}.{event}.noncoding.fdr-controlled.tsv",
+        coding="results/tables/{group}.{any_event}.coding.fdr-controlled.tsv",
+        noncoding="results/tables/{group}.{any_event}.noncoding.fdr-controlled.tsv",
     params:
-        sorting=lambda wc: config["calling"]["fdr-control"]["events"][wc.event].get(
-            "sort", list()
-        ),
+        sorting=lambda wc:
+            lookup(within=config, dpath="complement_events/{wc.any_event}/sort", default=list()) if wc.any_event in COMPLEMENT_EVENTS else
+            lookup(within=config, dpath="calling/fdr-control/events/{wc.any_event}/sort", default=list()),
     log:
-        "logs/split_tables/{group}.{event}.log",
+        "logs/split_tables/{group}.{any_event}.log",
     conda:
         "../envs/split_call_tables.yaml"
     script:
@@ -20,11 +20,11 @@ rule split_call_tables:
 
 rule process_fusion_call_tables:
     input:
-        "results/tables/{group}.{event}.fusions.fdr-controlled.tsv",
+        "results/tables/{group}.{any_event}.fusions.fdr-controlled.tsv",
     output:
-        fusions="results/tables/{group}.{event}.fusions.joined.fdr-controlled.tsv",
+        fusions="results/tables/{group}.{any_event}.fusions.joined.fdr-controlled.tsv",
     log:
-        "logs/join_partner/{group}.{event}.log",
+        "logs/join_partner/{group}.{any_event}.log",
     conda:
         "../envs/pandas.yaml"
     script:
@@ -36,15 +36,15 @@ rule prepare_oncoprint:
         calls=get_oncoprint_input,
         group_annotation=config.get("groups", []),
     output:
-        gene_oncoprint="results/tables/oncoprints/{batch}.{event}/gene-oncoprint.tsv",
+        gene_oncoprint="results/tables/oncoprints/{batch}.{any_event}/gene-oncoprint.tsv",
         gene_oncoprint_sortings=directory(
-            "results/tables/oncoprints/{batch}.{event}/label_sortings/"
+            "results/tables/oncoprints/{batch}.{any_event}/label_sortings/"
         ),
         variant_oncoprints=directory(
-            "results/tables/oncoprints/{batch}.{event}/variant-oncoprints"
+            "results/tables/oncoprints/{batch}.{any_event}/variant-oncoprints"
         ),
     log:
-        "logs/prepare_oncoprint/{batch}.{event}.log",
+        "logs/prepare_oncoprint/{batch}.{any_event}.log",
     params:
         groups=get_report_batch("variants"),
         labels=get_heterogeneous_labels(),
@@ -76,11 +76,11 @@ rule datavzrd_variants_calls:
         ),
         gene_oncoprint=get_oncoprint("gene"),
         variant_oncoprints=get_oncoprint("variant"),
-        oncoprint_sorted_datasets="results/tables/oncoprints/{batch}.{event}/label_sortings/",
+        oncoprint_sorted_datasets="results/tables/oncoprints/{batch}.{any_event}/label_sortings/",
     output:
         report(
             directory(
-                "results/datavzrd-report/{batch}.{event}.variants.fdr-controlled"
+                "results/datavzrd-report/{batch}.{any_event}.variants.fdr-controlled"
             ),
             htmlindex="index.html",
             caption="../report/calls.rst",
@@ -89,7 +89,7 @@ rule datavzrd_variants_calls:
             subcategory=get_datavzrd_report_subcategory,
         ),
     log:
-        "logs/datavzrd_report/{batch}.{event}.log",
+        "logs/datavzrd_report/{batch}.{any_event}.log",
     params:
         variant_oncoprints=get_variant_oncoprint_tables,
         groups=get_report_batch("variants"),
@@ -100,7 +100,7 @@ rule datavzrd_variants_calls:
         group_annotations=group_annotation,
         labels=get_heterogeneous_labels(),
         event_desc=lookup(
-            dpath="calling/fdr-control/events/{event}/desc", within=config
+            dpath="calling/fdr-control/events/{any_event}/desc", within=config
         ),
     wrapper:
         "v5.6.1/utils/datavzrd"
@@ -127,7 +127,7 @@ rule datavzrd_fusion_calls:
     output:
         report(
             directory(
-                "results/datavzrd-report/{batch}.{event}.fusions.fdr-controlled"
+                "results/datavzrd-report/{batch}.{any_event}.fusions.fdr-controlled"
             ),
             htmlindex="index.html",
             caption="../report/calls.rst",
@@ -136,7 +136,7 @@ rule datavzrd_fusion_calls:
             subcategory=get_datavzrd_report_subcategory,
         ),
     log:
-        "logs/datavzrd_report/{batch}.{event}.log",
+        "logs/datavzrd_report/{batch}.{any_event}.log",
     params:
         groups=get_report_batch("fusions"),
         samples=samples,

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -7,19 +7,7 @@ rule split_call_tables:
         coding="results/tables/{group}.{any_event}.coding.fdr-controlled.tsv",
         noncoding="results/tables/{group}.{any_event}.noncoding.fdr-controlled.tsv",
     params:
-        sorting=lambda wc: (
-            lookup(
-                within=config,
-                dpath="complement_events/{wc.any_event}/sort",
-                default=list(),
-            )
-            if wc.any_event in COMPLEMENT_EVENTS
-            else lookup(
-                within=config,
-                dpath="calling/fdr-control/events/{wc.any_event}/sort",
-                default=list(),
-            )
-        ),
+        sorting=lambda wc: lookup(within=get_any_event(wc), dpath="sort", default=list()),
     log:
         "logs/split_tables/{group}.{any_event}.log",
     conda:
@@ -109,9 +97,7 @@ rule datavzrd_variants_calls:
         samples=samples,
         group_annotations=group_annotation,
         labels=get_heterogeneous_labels(),
-        event_desc=lookup(
-            dpath="calling/fdr-control/events/{any_event}/desc", within=config
-        ),
+        event_desc=lambda wc: lookup(within=get_any_event(wc), dpath="desc", default="No description provided"),
     wrapper:
         "v5.6.1/utils/datavzrd"
 

--- a/workflow/rules/filtering.smk
+++ b/workflow/rules/filtering.smk
@@ -114,11 +114,15 @@ rule complement_event:
     input:
         full=lambda w: expand(
             "results/final-calls/{{group}}.{full_event}.{{calling_type}}.fdr-controlled.bcf",
-            full_event=lookup(within=config, dpath=f"complement_events/{w.complement_event}/full"),
+            full_event=lookup(
+                within=config, dpath=f"complement_events/{w.complement_event}/full"
+            ),
         ),
         full_idx=lambda w: expand(
             "results/final-calls/{{group}}.{full_event}.{{calling_type}}.fdr-controlled.bcf.csi",
-            full_event=lookup(within=config, dpath=f"complement_events/{w.complement_event}/full"),
+            full_event=lookup(
+                within=config, dpath=f"complement_events/{w.complement_event}/full"
+            ),
         ),
         exclude="results/final_merged/{group}.{complement_event}.{calling_type}.merged_exclude.bcf",
         exclude_idx="results/final_merged/{group}.{complement_event}.{calling_type}.merged_exclude.bcf.csi",

--- a/workflow/rules/filtering.smk
+++ b/workflow/rules/filtering.smk
@@ -100,9 +100,9 @@ rule merge_exclude_events:
         calls=get_merge_exclude_events_input(".bcf"),
         idx=get_merge_exclude_events_input(".bcf.csi"),
     output:
-        "results/final_merged/{group}.{complement_event}.{calling_type}.merged_exclude.bcf"
+        "results/final_merged/{group}.{complement_event}.{calling_type}.merged_exclude.bcf",
     log:
-        "logs/merge_exclude_events/{group}.{complement_event}.{calling_type}.log"
+        "logs/merge_exclude_events/{group}.{complement_event}.{calling_type}.log",
     params:
         extra="-a",
     threads: 4
@@ -114,7 +114,7 @@ rule complement_event:
     input:
         full=lambda w: expand(
             "results/final-calls/{{group}}.{full_event}.{calling_type}.fdr-controlled.norm.bcf",
-            full_event=config['calling']['complement'][w.complement_event]['full'],
+            full_event=config["calling"]["complement"][w.complement_event]["full"],
         ),
         exclude="results/final_merged/{group}.{complement_event}.{calling_type}.merged_exclude.bcf",
     output:
@@ -124,7 +124,9 @@ rule complement_event:
     conda:
         "../envs/bcftools.yaml"
     params:
-        aliases = lambda w: ','.join(list(samples.loc[samples['group'] == w.group, 'alias']))
+        aliases=lambda w: ",".join(
+            list(samples.loc[samples["group"] == w.group, "alias"])
+        ),
     threads: 3
     shell:
         """

--- a/workflow/rules/maf.smk
+++ b/workflow/rules/maf.smk
@@ -33,12 +33,12 @@ rule group_vcf_to_maf:
             dpath="maf/primary_alias", within=config, default="tumor"
         ),
         vcf_control_alias_option=(
-            f'--vcf-normal-id {lookup(dpath = "maf/control_alias", within = config , default = "")}'
+            f'--vcf-normal-id {lookup(dpath= "maf/control_alias", within= config, default= "")}'
             if lookup(dpath="maf/control_alias", within=config, default=False)
             else ""
         ),
         normal_id=lambda wc: (
-            f'--normal-id {wc.group}_{lookup(dpath = "maf/control_alias", within = config , default = "")}'
+            f'--normal-id {wc.group}_{lookup(dpath= "maf/control_alias", within= config, default= "")}'
             if lookup(dpath="maf/control_alias", within=config, default=False)
             else ""
         ),

--- a/workflow/rules/table.smk
+++ b/workflow/rules/table.smk
@@ -1,15 +1,15 @@
 rule vembrane_table:
     input:
-        bcf="results/final-calls/{group}.{event}.{calling_type}.fdr-controlled.normal-probs.bcf",
+        bcf="results/final-calls/{group}.{any_event}.{calling_type}.fdr-controlled.normal-probs.bcf",
         scenario="results/scenarios/{group}.yaml",
     output:
-        bcf="results/tables/{group}.{event}.{calling_type}.fdr-controlled.tsv",
+        bcf="results/tables/{group}.{any_event}.{calling_type}.fdr-controlled.tsv",
     conda:
         "../envs/vembrane.yaml"
     params:
         config=lambda wc, input: get_vembrane_config(wc, input),
     log:
-        "logs/vembrane-table/{group}.{event}.{calling_type}.log",
+        "logs/vembrane-table/{group}.{any_event}.{calling_type}.log",
     shell:
         'vembrane table --header "{params.config[header]}" "{params.config[expr]}" '
         "{input.bcf} > {output.bcf} 2> {log}"


### PR DESCRIPTION
The use case that motivates this, is to generate a datavzrd report table for all the candidate variants that were filtered out due to their `PROB_ARTIFACT` during FDR control filtering.

The only way that I see to cleanly do this, is to generate two variant sets:

1. A regular variant set that excludes artifacts as is usually intended.
2. A second variant set based on the same varlociraptor events, but with `retain-artifacts: true` set.

We can then take the complement of 1 in 2, to extract those candidate variants that are only found in 2 (with `retain-artifacts: true`).

This functionality might also be interesting for other debugging scenarios or intensive inspection of variant sets, but is probably not common enough to warrant putting it in the main default `config/config.yaml` that comes with every `snakedeploy`ment as a module.