### PR TITLE
fix: multiple minor fixes

### DIFF
--- a/workflow/envs/arriba.post-deploy.sh
+++ b/workflow/envs/arriba.post-deploy.sh
@@ -1,4 +1,0 @@
-#!env bash
-
-# Replace convert_fusions_to_vcf.sh script by updated one until new version of arriba is released
-curl https://raw.githubusercontent.com/suhrig/arriba/6fff196/scripts/convert_fusions_to_vcf.sh > $CONDA_PREFIX/bin/convert_fusions_to_vcf.sh

--- a/workflow/envs/arriba.yaml
+++ b/workflow/envs/arriba.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - arriba =2.4
+  - arriba =2.5

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -11,7 +11,7 @@ samples = (
     pd.read_csv(
         config["samples"],
         sep="\t",
-        dtype={"sample_name": str, "group": str},
+        dtype={"sample_name": str, "group": str, "umi_len": "Int64"},
         comment="#",
     )
     .set_index("sample_name", drop=False)

--- a/workflow/rules/fusion_calling.smk
+++ b/workflow/rules/fusion_calling.smk
@@ -1,6 +1,6 @@
 module fusion_calling:
     meta_wrapper:
-        "v3.13.3/meta/bio/star_arriba"
+        "v7.1.0/meta/bio/star_arriba"
     config:
         config
 

--- a/workflow/scripts/split-call-tables.py
+++ b/workflow/scripts/split-call-tables.py
@@ -173,7 +173,6 @@ class PopulationDb:
             self.pos = pos
             self._variants = self._load_variants()
         for variant in self._variants:
-            print(variant.pos)
             if variant.pos == pos and variant.alts[0] == alt:
                 yield variant
             if variant.pos > pos:

--- a/workflow/scripts/split-call-tables.py
+++ b/workflow/scripts/split-call-tables.py
@@ -195,7 +195,6 @@ class PopulationDb:
         )
 
     def _load_variants(self):
-        print(self.pos)
         return self.bcf.fetch(str(self.contig), self.pos - 1, self.end)
 
     @property


### PR DESCRIPTION
This PR includes some minor fixes, changes and cleanups.

fix: When the column 'umi_len' has empty cells it automatically gets interpreted as float leading to an invalid parameterization of fastp. This has been fixed by setting the column to Int64.
change: We needed to apply a post-deploy script to the arriba environment in order to covert fusion calls to vcf record. The latest version of arriba includes that conversion script and there for the post-deploy script is not necessary anymore.
cleanup: removed a print command for debugging from split-call-tables.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of sample files by explicitly supporting a nullable integer type for the "umi_len" column.

* **Bug Fixes**
  * Removed extraneous debugging output from variant table processing.

* **Chores**
  * Updated the "arriba" package version to 2.5 for improved fusion calling.
  * Upgraded the "star_arriba" workflow component to a newer version.
  * Removed an obsolete script used for updating fusion conversion tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->