### PR TITLE
fix: Upgrade wrappers from 7.2.0 to 7.3.0 with https update to vep-cache rule

### DIFF
--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -11,7 +11,7 @@ rule get_genome:
         chromosome=config["ref"].get("chromosome"),
     cache: "omit-software"
     wrapper:
-        "v7.2.0/bio/reference/ensembl-sequence"
+        "v7.3.0/bio/reference/ensembl-sequence"
 
 
 rule genome_faidx:
@@ -56,7 +56,7 @@ rule get_known_variants:
         chromosome=config["ref"].get("chromosome"),
     cache: "omit-software"
     wrapper:
-        "v7.2.0/bio/reference/ensembl-variation"
+        "v7.3.0/bio/reference/ensembl-variation"
 
 
 rule get_annotation:
@@ -71,7 +71,7 @@ rule get_annotation:
         "logs/get_annotation.log",
     cache: "omit-software"  # save space and time with between workflow caching (see docs)
     wrapper:
-        "v7.2.0/bio/reference/ensembl-annotation"
+        "v7.3.0/bio/reference/ensembl-annotation"
 
 
 rule determine_coding_regions:
@@ -134,7 +134,7 @@ rule get_vep_cache:
         "logs/vep/cache.log",
     cache: "omit-software"
     wrapper:
-        "v7.2.0/bio/vep/cache"
+        "v7.3.0/bio/vep/cache"
 
 
 rule get_vep_plugins:
@@ -145,7 +145,7 @@ rule get_vep_plugins:
     log:
         "logs/vep/plugins.log",
     wrapper:
-        "v7.2.0/bio/vep/plugins"
+        "v7.3.0/bio/vep/plugins"
 
 
 rule get_pangenome:


### PR DESCRIPTION
This pull request updates several workflow rules in `workflow/rules/ref.smk` to use newer versions of their respective wrappers. All affected rules now reference version `v7.3.0` of their wrappers, up from `v7.2.0`. This ensures the workflow uses the latest features and bug fixes from these wrapper updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated reference data wrappers to the latest release (v7.3.0), covering genome sequences, known variants, and annotation.
  - Refreshed VEP resources by upgrading cache and plugin wrappers to v7.3.0 for improved compatibility and stability.
  - No changes to public interfaces; existing workflows continue to operate as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->