### PR TITLE
fix: Upgrade wrapper versions to v7.5.0

### DIFF
--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -71,7 +71,7 @@ rule get_annotation:
         "logs/get_annotation.log",
     cache: "omit-software"  # save space and time with between workflow caching (see docs)
     wrapper:
-        "v7.4.0/bio/reference/ensembl-annotation"
+        "v7.5.0/bio/reference/ensembl-annotation"
 
 
 rule determine_coding_regions:


### PR DESCRIPTION
This pull request makes a minor update to the `get_annotation` rule in the `workflow/rules/ref.smk` file. The rule now uses version `v7.4.0` of the `ensembl-annotation` wrapper instead of `v7.3.0`, ensuring the workflow uses the latest annotation logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Ensembl-related wrappers (variation, annotation, and VEP cache) to v7.5.0. This updates upstream reference and cache sources while keeping inputs, outputs, parameters, logging, control flow, and error handling unchanged. No expected impact on workflow configuration or execution; results remain consistent aside from upstream annotation/cache updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->