### PR TITLE
feat: integrate hla typing with orthanq

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
             args: >-
               --configfile .test/config-sra/config.yaml
             report: true
-            cleanup: false
+            cleanup: true
     name: test ${{ matrix.case.name }}
 
     steps:

--- a/.test/config-chm-eval/config.yaml
+++ b/.test/config-chm-eval/config.yaml
@@ -36,6 +36,14 @@ mutational_signatures:
   events:
     - some_id
 
+hla_typing:
+  activate: false
+  loci: 
+    - "A"
+    - "B"
+    - "C"
+    - "DQB1"
+    
 calling:
   delly:
     activate: true

--- a/.test/config-giab/config.yaml
+++ b/.test/config-giab/config.yaml
@@ -57,6 +57,14 @@ mutational_signatures:
   events:
     - some_id
 
+hla_typing:
+  activate: false
+  loci: 
+    - "A"
+    - "B"
+    - "C"
+    - "DQB1"
+    
 # printing of variants in a matrix, sorted by recurrence
 report:
   # if stratificatio is deactivated, one oncoprint for all

--- a/.test/config-no-candidate-filtering/config.yaml
+++ b/.test/config-no-candidate-filtering/config.yaml
@@ -37,6 +37,14 @@ mutational_signatures:
   events:
     - some_id
 
+hla_typing:
+  activate: false
+  loci: 
+    - "A"
+    - "B"
+    - "C"
+    - "DQB1"
+    
 calling:
   delly:
     activate: true

--- a/.test/config-simple/config.yaml
+++ b/.test/config-simple/config.yaml
@@ -36,6 +36,14 @@ mutational_signatures:
   events:
     - some_id
 
+hla_typing:
+  activate: false
+  loci: 
+    - "A"
+    - "B"
+    - "C"
+    - "DQB1"
+    
 calling:
   delly:
     activate: true

--- a/.test/config-sra/config.yaml
+++ b/.test/config-sra/config.yaml
@@ -34,6 +34,14 @@ mutational_signatures:
   events:
     - some_id
 
+hla_typing:
+  activate: false
+  loci: 
+    - "A"
+    - "B"
+    - "C"
+    - "DQB1"
+    
 calling:
   delly:
     activate: true

--- a/.test/config-target-regions/config.yaml
+++ b/.test/config-target-regions/config.yaml
@@ -37,6 +37,14 @@ mutational_signatures:
   events:
     - some_id
 
+hla_typing:
+  activate: false
+  loci: 
+    - "A"
+    - "B"
+    - "C"
+    - "DQB1"
+    
 calling:
   delly:
     activate: true

--- a/.test/config-target-regions/config_multiple_beds.yaml
+++ b/.test/config-target-regions/config_multiple_beds.yaml
@@ -39,6 +39,14 @@ mutational_signatures:
   events:
     - some_id
 
+hla_typing:
+  activate: false
+  loci: 
+    - "A"
+    - "B"
+    - "C"
+    - "DQB1"
+    
 calling:
   delly:
     activate: true

--- a/.test/config_primers/config.yaml
+++ b/.test/config_primers/config.yaml
@@ -38,6 +38,14 @@ mutational_signatures:
   events:
     - some_id
 
+hla_typing:
+  activate: false
+  loci: 
+    - "A"
+    - "B"
+    - "C"
+    - "DQB1"
+
 calling:
   delly:
     activate: true

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -80,6 +80,11 @@ mutational_signatures:
 
 hla_typing:
   activate: false
+  loci: 
+    - "A"
+    - "B"
+    - "C"
+    - "DQB1"
 
 # Sets the minimum average coverage for each gene.
 # Genes with lower average coverage will not be concidered in gene coverage datavzrd report

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -77,6 +77,10 @@ mutational_signatures:
     # select events (callsets, defined under calling/fdr-control/events) to evaluate
     - some_id
 
+
+hla_typing:
+  activate: false
+
 # Sets the minimum average coverage for each gene.
 # Genes with lower average coverage will not be concidered in gene coverage datavzrd report
 # If not present min_avg_coverage will be set to 0 rendering all genes.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,10 +10,20 @@ units: config/units.tsv
 # group is a patient or individual).
 # The given data will be shown in the header of the reported
 # variant call overview tables.
-# groups: config/groups.tsv
+
+#example working config for hla typing.
+
+groups: config/groups.tsv
 
 # Optional BED file with target regions
 # target_regions: "path/to/taget-regions.bed"
+
+events:
+  __definitions__:
+    - somatic_tumor = "normal:0.0 & tumor:]0.0,1.0]"
+    - somatic_resection = "normal:0.0 & tumor:0.0 & resection:]0.0,1.0]"
+    - germline = "normal:0.5 | normal:1.0"
+    - somatic_normal = "normal:]0.0,0.5["
 
 ref:
   # Number of chromosomes to consider for calling.
@@ -22,7 +32,7 @@ ref:
   # Ensembl species name
   species: homo_sapiens
   # Ensembl release
-  release: 111
+  release: 108
   # Genome build
   build: GRCh38
   pangenome: 
@@ -66,25 +76,24 @@ mutational_burden:
   # considering the sum of the posterior probabilties of the
   # given events.
   events:
-    - somatic_tumor_low
-    - somatic_tumor_medium
-    - somatic_tumor_high
+    - somatic_tumor
 
 # Quantify known mutational signatures (human only)
 mutational_signatures:
   activate: false
   events:
     # select events (callsets, defined under calling/fdr-control/events) to evaluate
-    - some_id
+    - somatic_tumor
 
 
 hla_typing:
-  activate: false
+  activate: true
   loci: 
     - "A"
     - "B"
     - "C"
     - "DQB1"
+  prior: diploid #can only be diploid, diploid-subclonal and uniform
 
 # Sets the minimum average coverage for each gene.
 # Genes with lower average coverage will not be concidered in gene coverage datavzrd report
@@ -96,7 +105,7 @@ gene_coverage:
 report:
   # if stratification is deactivated, one report for all
   # samples will be created.
-  activate: true
+  activate: false
   max_read_depth: 250
   stratify:
     activate: false
@@ -185,9 +194,8 @@ calling:
           # Add varlociraptor events to aggregated over.
           # The probability for the union of these events is used for controlling
           # the FDR.
-          - present
-          - somatic_tumor_high
-          - somatic_tumor_medium
+          - somatic_tumor
+          - somatic_normal
         filter: # myfilter
           # Add any number of filters here.
           # A single filter can be set as string.
@@ -218,8 +226,7 @@ population:
     fdr: 0.05
     # Varlociraptor events to be used.
     events:
-      - somatic_tumor_high
-      - somatic_tumor_medium
+      - somatic_tumor
 
 annotations:
   vcfs:

--- a/config/scenario.yaml
+++ b/config/scenario.yaml
@@ -8,27 +8,73 @@
 # In addition, a variable `group_annotation` is available, which holds the row of the group
 # from the group annotation table (if specified in the config) as a pandas Series.
 
+#example working config for hla typing.
+
 __definitions__:
-  - samples = params.samples.set_index("alias")
+  - samples = params.samples
   - |
-    def contamination():
-      return 1.0 - float(samples.loc["tumor", "purity"])
+    def contamination(alias):
+      return 1.0 - samples.loc[samples["alias"] == alias, "purity"].squeeze()
+  - sex = params.annotation["sex"]
+  - has_biopsy = (samples["alias"] == "tumor_biopsy").any()
+  - resection_aliases = samples.loc[samples["alias"].str.startswith("tumor_resection"), "alias"]
+  - n_resection_aliases = len(resection_aliases)
+
+species:
+  heterozygosity: 0.001
+  ploidy:
+    male:
+      all: 2
+      X: 1
+      Y: 1
+    female:
+      all: 2
+      X: 2
+      Y: 0
 
 samples:
-  tumor:
-    resolution: 0.01
-    universe: "[0.0,1.0]"
-    contamination:
-      by: normal
-      fraction: ?contamination()
   normal:
     resolution: 0.1
-    universe: "0.0 | 0.5 | 1.0 | ]0.0,0.5["
+    sex: ?sex
+    somatic-effective-mutation-rate: 1e-6
+  ?for ralias in resection_aliases:
+    ?ralias:
+      resolution: 0.01
+      sex: ?sex
+      somatic-effective-mutation-rate: 1e-6
+      inheritance:
+        ?if has_biopsy:
+          subclonal:
+            from: tumor_biopsy
+        ?else:
+          clonal:
+            from: normal
+            somatic: true
+      ?if contamination(ralias) > 0.0:
+        contamination:
+          by: normal
+          fraction: ?float(contamination(ralias))
+  ?if has_biopsy:
+    tumor_biopsy:
+      resolution: 0.01
+      sex: ?sex
+      somatic-effective-mutation-rate: 1e-6
+      inheritance:
+        clonal:
+          from: normal
+          somatic: true
+      ?if contamination("tumor_biopsy") > 0.0:
+        contamination:
+          by: normal
+          fraction: ?float(contamination('tumor_biopsy'))
 
 events:
-  somatic_tumor_low: "tumor:]0.0,0.1[ & normal:0.0"
-  somatic_tumor_medium: "tumor:[0.1,0.3[ & normal:0.0"
-  somatic_tumor_high: "tumor:[0.3,1.0] & normal:0.0"
+  ?if n_resection_aliases > 0 and has_biopsy:
+    somatic_tumor: "normal:0.0 & tumor_biopsy:]0.0,1.0]"
+    somatic_resection: "normal:0.0 & tumor_biopsy:0.0 & tumor_resection:]0.0,1.0]"
+  ?elif n_resection_aliases > 0:
+    somatic_resection: "normal:0.0 & tumor_resection:]0.0,1.0]"
+  ?elif has_biopsy:
+    somatic_tumor: "normal:0.0 & tumor_biopsy:]0.0,1.0]"
+  germline: "normal:0.5 | normal:1.0"
   somatic_normal: "normal:]0.0,0.5["
-  germline_hom: "normal:1.0"
-  germline_het: "normal:0.5"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -44,6 +44,7 @@ include: "rules/fusion_calling.smk"
 include: "rules/testcase.smk"
 include: "rules/population.smk"
 include: "rules/mutational_signatures.smk"
+include: "rules/hla_typing.smk"
 
 
 batches = "all"

--- a/workflow/envs/orthanq-deps.yaml
+++ b/workflow/envs/orthanq-deps.yaml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - samtools >=1.23
+  - minimap2 >=2.30

--- a/workflow/envs/orthanq.yaml
+++ b/workflow/envs/orthanq.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - orthanq =1.15.0

--- a/workflow/envs/unzip.yaml
+++ b/workflow/envs/unzip.yaml
@@ -1,0 +1,4 @@
+channels:
+  - conda-forge
+dependencies:
+  - unzip =6.0

--- a/workflow/envs/varlociraptor.yaml
+++ b/workflow/envs/varlociraptor.yaml
@@ -3,6 +3,6 @@ channels:
   - bioconda
   - nodefaults
 dependencies:
-  - varlociraptor =8.7.3
+  - varlociraptor =8.9.5
   - vega-lite-cli =5.16
   - bcftools =1.21

--- a/workflow/envs/vega.yaml
+++ b/workflow/envs/vega.yaml
@@ -2,3 +2,4 @@ channels:
   - conda-forge
 dependencies:
   - vega-lite-cli =5.16
+  - vl-convert =1.2.0

--- a/workflow/rules/calling.smk
+++ b/workflow/rules/calling.smk
@@ -59,7 +59,7 @@ rule varlociraptor_preprocess:
     conda:
         "../envs/varlociraptor.yaml"
     shell:
-        "varlociraptor preprocess variants --candidates {input.candidates} {params.extra} "
+        "varlociraptor preprocess variants --omit-mapq-adjustment --candidates {input.candidates} {params.extra} "
         "--alignment-properties {input.alignment_props} {input.ref} --bam {input.bam} --output {output} "
         "2> {log}"
 

--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -72,7 +72,9 @@ rule filter_offtarget_variants:
 
 rule scatter_candidates:
     input:
-        get_scatter_candidates_input,
+        "results/candidate-calls/{group}.{caller}.filtered.bcf"
+        if config.get("target_regions", None)
+        else get_fixed_candidate_calls("bcf"),
     output:
         scatter.calling(
             "results/candidate-calls/{{group}}.{{caller}}.{scatteritem}.bcf"

--- a/workflow/rules/candidate_calling.smk
+++ b/workflow/rules/candidate_calling.smk
@@ -72,9 +72,7 @@ rule filter_offtarget_variants:
 
 rule scatter_candidates:
     input:
-        "results/candidate-calls/{group}.{caller}.filtered.bcf"
-        if config.get("target_regions", None)
-        else get_fixed_candidate_calls("bcf"),
+        get_scatter_candidates_input,
     output:
         scatter.calling(
             "results/candidate-calls/{{group}}.{{caller}}.{scatteritem}.bcf"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -172,7 +172,7 @@ def get_final_output(wildcards):
         for group in samples["group"].unique():
             final_output.extend(
                 expand(
-                    "results/hla-typing/{group}-{locus}/{alias}/{alias}-{locus}.csv",
+                    "results/hla-typing/{group}-{locus}/{alias}/",
                     alias=get_group_aliases(group),
                     group=group,
                     locus=loci,

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -166,8 +166,9 @@ def get_final_output(wildcards):
     if is_activated("hla_typing"):
         final_output.extend(
             expand(
-                "results/hla-typing/{item.group}.{item.sample}.tsv",
-                item=samples.itertuples(),
+                "results/hla-typing/{group}_{locus}/{group}_{locus}.csv",
+                group=groups,
+                locus=config["hla_typing"].get("loci")
             )
         )
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -170,7 +170,8 @@ def get_final_output(wildcards):
     if is_activated("hla_typing"):
         final_output.extend(
             expand(
-                "results/hla-typing/{group}-{locus}/{group}-{locus}.csv",
+                "results/hla-typing/{group}-{locus}/{sample}/{sample}-{locus}.csv",
+                sample=samples["sample_name"].unique(),
                 group=groups,
                 locus=[
                     f"orthanq-{locus}" for locus in config["hla_typing"].get("loci")

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -773,7 +773,7 @@ def get_gather_annotated_calls_input(ext="bcf"):
 
 def get_scatter_candidates_input(wildcards):
     if wildcards.caller == "orthanq":
-        return "results/candidate-calls/orthanq.bcf"
+        return "results/candidate-calls/orthanq.{locus}.bcf"
     elif config.get("target_regions"):
         return "results/candidate-calls/{group}.{caller}.filtered.bcf"
     else:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -168,16 +168,16 @@ def get_final_output(wildcards):
     )
 
     if is_activated("hla_typing"):
-        final_output.extend(
-            expand(
-                "results/hla-typing/{group}-{locus}/{sample}/{sample}-{locus}.csv",
-                sample=samples["sample_name"].unique(),
-                group=groups,
-                locus=[
-                    f"orthanq-{locus}" for locus in config["hla_typing"].get("loci")
-                ],
+        loci = [f"orthanq-{locus}" for locus in config["hla_typing"].get("loci", [])]
+        for group in samples["group"].unique():
+            final_output.extend(
+                expand(
+                    "results/hla-typing/{group}-{locus}/{alias}/{alias}-{locus}.csv",
+                    alias=get_group_aliases(group),
+                    group=group,
+                    locus=loci,
+                )
             )
-        )
 
     for calling_type in calling_types:
         if config["report"]["activate"]:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -48,6 +48,7 @@ delly_excluded_regions = {
 hla_loci = config.get("hla_typing", {}).get("loci", [])
 orthanq_callers = [f"orthanq-{locus}" for locus in hla_loci]
 
+
 def _group_or_sample(row):
     group = row.get("group", None)
     if pd.isnull(group):
@@ -171,7 +172,9 @@ def get_final_output(wildcards):
             expand(
                 "results/hla-typing/{group}-{locus}/{group}-{locus}.csv",
                 group=groups,
-                locus=[f"orthanq-{locus}" for locus in config['hla_typing'].get('loci')]
+                locus=[
+                    f"orthanq-{locus}" for locus in config["hla_typing"].get("loci")
+                ],
             )
         )
 
@@ -720,7 +723,9 @@ def get_scattered_calls(ext="bcf"):
             case "variants":
                 caller = variant_caller
             case "hla-variants":
-                caller = [f"orthanq-{locus}" for locus in config['hla_typing'].get('loci', [])]
+                caller = [
+                    f"orthanq-{locus}" for locus in config["hla_typing"].get("loci", [])
+                ]
             case _:
                 raise ValueError(
                     f"Unexpected wildcard value for 'calling_type': {wildcards.calling_type}"
@@ -785,7 +790,7 @@ def get_gather_annotated_calls_input(ext="bcf"):
 
 def get_candidate_calls(wc):
     filter = config["calling"]["filter"].get("candidates")
-    #only use orthanq path if caller is one of the orthanq loci
+    # only use orthanq path if caller is one of the orthanq loci
     if is_activated("hla_typing") and wc.caller.startswith("orthanq-"):
         return "results/orthanq-candidate-calls/{caller}.hla-variants.{scatteritem}.bcf"
 
@@ -986,7 +991,9 @@ def get_candidate_filter_aux_files():
         return []
     else:
         # aux files are considered as part of the config, hence local
-        return [local(path) for name, path in get_filter_aux_entries("candidates").items()]
+        return [
+            local(path) for name, path in get_filter_aux_entries("candidates").items()
+        ]
 
 
 def get_candidate_filter_aux(wildcards, input):
@@ -995,7 +1002,9 @@ def get_candidate_filter_aux(wildcards, input):
     else:
         return [
             f"--aux {name}={path}"
-            for name, path in zip(get_filter_aux_entries("candidates").keys(), input.aux)
+            for name, path in zip(
+                get_filter_aux_entries("candidates").keys(), input.aux
+            )
         ]
 
 
@@ -1517,7 +1526,7 @@ def get_primer_extra(wc, input):
     min_primer_len = get_shortest_primer_length(input.reads)
     # Check if shortest primer is below default values
     if min_primer_len < 32:
-        extra += f" -T {min_primer_len - 2}"
+        extra += f" -T {min_primer_len-2}"
     if min_primer_len < 19:
         extra += f" -k {min_primer_len}"
     return extra

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -155,6 +155,41 @@ def get_heterogeneous_labels():
 
 
 def get_final_output(wildcards):
+
+    final_output = []
+    
+    if is_activated("hla_typing"):
+        loci = [f"orthanq-{locus}" for locus in config["hla_typing"].get("loci", [])]
+
+        for group in samples["group"].unique():
+            aliases = get_group_aliases(group)
+
+            for alias in aliases:
+                # prior = "diploid" if alias == "normal" else "diploid-subclonal" #todo: reactivate once the diploid-subclonal is ready.
+                prior = "diploid"
+
+                final_output.extend(
+                    expand(
+                        [
+                            "results/hla-typing/{group}-{locus}/{alias}/{prior}/predictions.csv",
+                            "results/hla-typing/{group}-{locus}/{alias}/{prior}/3_field_solutions.html",
+                            "results/hla-typing/{group}-{locus}/{alias}/{prior}/3_field_solutions.svg",
+                            "results/hla-typing/{group}-{locus}/{alias}/{prior}/2_field_solutions.html",
+                            "results/hla-typing/{group}-{locus}/{alias}/{prior}/2_field_solutions.svg",
+                            "results/hla-typing/{group}-{locus}/{alias}/{prior}/arrow_plot.html",
+                            "results/hla-typing/{group}-{locus}/{alias}/{prior}/arrow_plot.svg",
+                            "results/hla-typing/{group}-{locus}/{alias}/{prior}/best_solution.html",
+                            "results/hla-typing/{group}-{locus}/{alias}/{prior}/best_solution.svg",
+                        ],
+                        alias=alias,
+                        group=group,
+                        locus=loci,
+                        prior=prior,
+                    )
+                )
+
+    return final_output
+
     final_output = expand(
         "results/qc/multiqc/{group}.html",
         group=groups,
@@ -166,18 +201,6 @@ def get_final_output(wildcards):
             group=groups,
         )
     )
-
-    if is_activated("hla_typing"):
-        loci = [f"orthanq-{locus}" for locus in config["hla_typing"].get("loci", [])]
-        for group in samples["group"].unique():
-            final_output.extend(
-                expand(
-                    "results/hla-typing/{group}-{locus}/{alias}/",
-                    alias=get_group_aliases(group),
-                    group=group,
-                    locus=loci,
-                )
-            )
 
     for calling_type in calling_types:
         if config["report"]["activate"]:
@@ -1686,3 +1709,20 @@ def get_pangenome_url(datatype):
             "Unsupported pangenome source. Only 'hprc' is currently supported."
         )
     return f"https://s3-us-west-2.amazonaws.com/human-pangenomics/pangenomes/freeze/freeze1/minigraph-cactus/hprc-{version}-mc-{build}/hprc-{version}-mc-{build}.{datatype}"
+
+def get_events(wildcards):
+    group_samples = samples[samples["group"] == wildcards.group]
+
+    has_biopsy = "tumor_biopsy" in group_samples["alias"].values
+
+    if wildcards.alias == "normal":
+        return "germline somatic_normal"
+
+    elif wildcards.alias == "tumor_biopsy":
+        return "somatic_tumor germline somatic_normal"
+
+    elif wildcards.alias == "tumor_resection":
+        if has_biopsy:
+            return "somatic_resection somatic_tumor germline somatic_normal"
+        else:
+            return "somatic_resection germline somatic_normal"

--- a/workflow/rules/hla_typing.smk
+++ b/workflow/rules/hla_typing.smk
@@ -86,19 +86,19 @@ rule orthanq_call:
         haplotype_calls="results/calls/{group}.{caller}.bcf",
         xml="results/preparation/hla.xml",
     output:  #orthanq uses underscore for a separator of sample/group name and locus name.
-        table="results/hla-typing/{group}-{caller}/{sample}/{sample}-{caller}.csv",
-        three_field_solutions="results/hla-typing/{group}-{caller}/{sample}/3_field_solutions.json",
-        two_field_solutions="results/hla-typing/{group}-{caller}/{sample}/2_field_solutions.json",
-        final_solution="results/hla-typing/{group}-{caller}/{sample}/final_solution.json",
-        lp_solution="results/hla-typing/{group}-{caller}/{sample}/lp_solution.json",
-        two_field_table="results/hla-typing/{group}-{caller}/{sample}/2-field.csv",
-        g_groups="results/hla-typing/{group}-{caller}/{sample}/G_groups.csv",
+        table="results/hla-typing/{group}-{caller}/{alias}/{alias}-{caller}.csv",
+        three_field_solutions="results/hla-typing/{group}-{caller}/{alias}/3_field_solutions.json",
+        two_field_solutions="results/hla-typing/{group}-{caller}/{alias}/2_field_solutions.json",
+        final_solution="results/hla-typing/{group}-{caller}/{alias}/final_solution.json",
+        lp_solution="results/hla-typing/{group}-{caller}/{alias}/lp_solution.json",
+        two_field_table="results/hla-typing/{group}-{caller}/{alias}/2-field.csv",
+        g_groups="results/hla-typing/{group}-{caller}/{alias}/G_groups.csv",
     log:
-        "logs/orthanq/{group}-{sample}-{caller}.log",
+        "logs/orthanq/{group}-{alias}-{caller}.log",
     conda:
         "../envs/orthanq.yaml"
     shell:
-        "orthanq call hla --haplotype-variants {input.haplotype_variants} --xml {input.xml} --sample {wildcards.sample} "
+        "orthanq call hla --haplotype-variants {input.haplotype_variants} --xml {input.xml} --sample {wildcards.alias} "
         " --haplotype-calls {input.haplotype_calls} --prior diploid --output {output.table} 2> {log}"
 
 

--- a/workflow/rules/hla_typing.smk
+++ b/workflow/rules/hla_typing.smk
@@ -1,0 +1,36 @@
+rule orthanq_candidate_variants:
+    input:
+        ...
+    output:
+        "results/candidate-calls/orthanq.bcf",
+    log:
+        "logs/orthanq-candidates.log",
+    shell:
+        "orthanq candidates ... --out-bcf {output} 2> {log}"
+
+
+rule gather_annotated_calls:
+    input:
+        calls=gather.calling("results/calls/{{group}}.orthanq.{scatteritem}.bcf"),
+        idx=gather.calling("results/calls/{{group}}.orthanq.{scatteritem}.bcf.csi"),
+    output:
+        "results/calls/{group}.hla-variants.bcf",
+    log:
+        "logs/gather-hla-variants/{group}.log",
+    params:
+        extra="-a",
+    group:
+        "annotation"
+    wrapper:
+        "v2.3.2/bio/bcftools/concat"
+
+
+rule orthanq_call:
+    input:
+        "results/calls/{group}.hla-variants.bcf",
+    output:
+        "results/hla-typing/{group}.{sample}.tsv",
+    log:
+        "logs/orthanq/{group}.{sample}.log",
+    shell:
+        "orthanq call {input} --sample {wildcards.sample} --out-table {output} 2> {log}"

--- a/workflow/rules/hla_typing.smk
+++ b/workflow/rules/hla_typing.smk
@@ -9,9 +9,8 @@ rule get_hla_genes_and_xml:
         genes_link="ftp://ftp.ebi.ac.uk/pub/databases/ipd/imgt/hla/hla_gen.fasta",
         xml_link="ftp://ftp.ebi.ac.uk/pub/databases/ipd/imgt/hla/xml/hla.xml.zip",
     shell:
-        "wget -c {params.genes_link} -O {output.genes} && "
-        "wget -c {params.xml_link} -O {output.xml} 2> {log}"
-
+        "wget -c {params.genes_link} -O {output.genes} 2> {log} && "
+        "wget -c {params.xml_link} -O {output.xml} 2>> {log}"
 
 rule unzip_xml:
     input:

--- a/workflow/rules/hla_typing.smk
+++ b/workflow/rules/hla_typing.smk
@@ -41,7 +41,7 @@ rule orthanq_candidate_variants:
         subcommand="hla",
         output_bcf=True 
     wrapper:
-        "v7.6.2/bio/orthanq"
+        "v7.7.0/bio/orthanq"
 
 
 rule rename_candidate_bcf:
@@ -102,7 +102,7 @@ rule orthanq_call_hla:
         prior="diploid",
         extra=""
     wrapper:
-        "v7.6.2/bio/orthanq"
+        "v7.7.0/bio/orthanq"
         
 # TODO add other outputs (plots), fill missing inputs and commands
 # TODO decide how to handle deactivation of biases in varlociraptor:

--- a/workflow/rules/hla_typing.smk
+++ b/workflow/rules/hla_typing.smk
@@ -32,7 +32,10 @@ rule orthanq_candidate_variants:
         xml="results/preparation/hla.xml",
         genome=genome,
     output:
-        bcfs=expand("results/orthanq-candidate-calls/{caller}.hla-variants.bcf", caller=[f"orthanq-{locus}" for locus in config['hla_typing'].get('loci')])
+        bcfs=expand(
+            "results/orthanq-candidate-calls/{caller}.hla-variants.bcf",
+            caller=[f"orthanq-{locus}" for locus in config["hla_typing"].get("loci")],
+        ),
     log:
         "logs/orthanq-candidates.log",
     conda:
@@ -44,10 +47,11 @@ rule orthanq_candidate_variants:
         "orthanq candidates hla --alleles {input.hla_genes} --genome {input.genome} --xml {input.xml} "
         "--threads {threads} --output-bcf --output {params.output_folder} 2> {log}"
 
-#since the scatter_candidates rule does not work without group wildcards.
+
+# since the scatter_candidates rule does not work without group wildcards.
 rule scatter_candidates_orthanq:
     input:
-        "results/orthanq-candidate-calls/{orthanq_locus}.hla-variants.bcf"
+        "results/orthanq-candidate-calls/{orthanq_locus}.hla-variants.bcf",
     output:
         scatter.calling(
             "results/orthanq-candidate-calls/{{orthanq_locus}}.hla-variants.{scatteritem}.bcf"
@@ -58,6 +62,7 @@ rule scatter_candidates_orthanq:
         "../envs/rbt.yaml"
     shell:
         "rbt vcf-split {input} {output}"
+
 
 rule gather_annotated_calls_orthanq:
     input:
@@ -80,7 +85,7 @@ rule orthanq_call:
         haplotype_variants="results/orthanq-candidate-calls/{caller}.hla-variants.bcf",
         haplotype_calls="results/calls/{group}.{caller}.bcf",
         xml="results/preparation/hla.xml",
-    output: #orthanq uses underscore for a separator of sample/group name and locus name.
+    output:  #orthanq uses underscore for a separator of sample/group name and locus name.
         table="results/hla-typing/{group}-{caller}/{group}-{caller}.csv",
         three_field_solutions="results/hla-typing/{group}-{caller}/3_field_solutions.json",
         two_field_solutions="results/hla-typing/{group}-{caller}/2_field_solutions.json",
@@ -95,6 +100,7 @@ rule orthanq_call:
     shell:
         "orthanq call hla --haplotype-variants {input.haplotype_variants} --xml {input.xml} "
         " --haplotype-calls {input.haplotype_calls} --prior diploid --output {output.table} 2> {log}"
+
 
 # TODO add other outputs (plots), fill missing inputs and commands
 # TODO decide how to handle deactivation of biases in varlociraptor:

--- a/workflow/rules/hla_typing.smk
+++ b/workflow/rules/hla_typing.smk
@@ -86,19 +86,19 @@ rule orthanq_call:
         haplotype_calls="results/calls/{group}.{caller}.bcf",
         xml="results/preparation/hla.xml",
     output:  #orthanq uses underscore for a separator of sample/group name and locus name.
-        table="results/hla-typing/{group}-{caller}/{group}-{caller}.csv",
-        three_field_solutions="results/hla-typing/{group}-{caller}/3_field_solutions.json",
-        two_field_solutions="results/hla-typing/{group}-{caller}/2_field_solutions.json",
-        final_solution="results/hla-typing/{group}-{caller}/final_solution.json",
-        lp_solution="results/hla-typing/{group}-{caller}/lp_solution.json",
-        two_field_table="results/hla-typing/{group}-{caller}/2-field.csv",
-        g_groups="results/hla-typing/{group}-{caller}/G_groups.csv",
+        table="results/hla-typing/{group}-{caller}/{sample}/{sample}-{caller}.csv",
+        three_field_solutions="results/hla-typing/{group}-{caller}/{sample}/3_field_solutions.json",
+        two_field_solutions="results/hla-typing/{group}-{caller}/{sample}/2_field_solutions.json",
+        final_solution="results/hla-typing/{group}-{caller}/{sample}/final_solution.json",
+        lp_solution="results/hla-typing/{group}-{caller}/{sample}/lp_solution.json",
+        two_field_table="results/hla-typing/{group}-{caller}/{sample}/2-field.csv",
+        g_groups="results/hla-typing/{group}-{caller}/{sample}/G_groups.csv",
     log:
-        "logs/orthanq/{group}-{caller}.log",
+        "logs/orthanq/{group}-{sample}-{caller}.log",
     conda:
         "../envs/orthanq.yaml"
     shell:
-        "orthanq call hla --haplotype-variants {input.haplotype_variants} --xml {input.xml} "
+        "orthanq call hla --haplotype-variants {input.haplotype_variants} --xml {input.xml} --sample {wildcards.sample} "
         " --haplotype-calls {input.haplotype_calls} --prior diploid --output {output.table} 2> {log}"
 
 

--- a/workflow/rules/hla_typing.smk
+++ b/workflow/rules/hla_typing.smk
@@ -1,22 +1,58 @@
+# dowloads latest IMGT/HLA database version
+rule get_hla_genes_and_xml:
+    output:
+        genes="results/preparation/hla_gen.fasta",
+        xml="results/preparation/hla.xml.zip",
+    log:
+        "logs/get_hla_genes_and_xml.log",
+    params:
+        genes_link="ftp://ftp.ebi.ac.uk/pub/databases/ipd/imgt/hla/hla_gen.fasta",
+        xml_link="ftp://ftp.ebi.ac.uk/pub/databases/ipd/imgt/hla/xml/hla.xml.zip",
+    shell:
+        "wget -c {params.genes_link} -O {output.genes} && "
+        "wget -c {params.xml_link} -O {output.xml} 2> {log}"
+
+
+rule unzip_xml:
+    input:
+        "results/preparation/hla.xml.zip",
+    output:
+        xml="results/preparation/hla.xml",
+    log:
+        "logs/unzip_xml.log",
+    params:
+        path_to_unzip=lambda wc, output: os.path.dirname(output.xml),
+    shell:
+        "unzip -o {input} -d {params.path_to_unzip}"
+
+
 rule orthanq_candidate_variants:
     input:
-        ...
+        hla_genes="results/preparation/hla_gen.fasta",
+        xml="results/preparation/hla.xml",
+        genome=genome,
     output:
-        "results/candidate-calls/orthanq.bcf",
+        bcfs=expand("results/candidate-calls/orthanq.{locus}.bcf", locus=config["hla_typing"].get("loci"))
     log:
         "logs/orthanq-candidates.log",
+    conda:
+        "../envs/orthanq.yaml"
+    params:
+        output_folder=lambda wc, output: os.path.dirname(output.bcfs[0]),
+    threads: 8
     shell:
-        "orthanq candidates ... --out-bcf {output} 2> {log}"
+        "orthanq candidates hla --alleles {input.hla_genes} --genome {input.genome} --xml {input.xml} "
+        "--threads {threads} --output-bcf --output {params.output_folder} 2> {log}"
 
 
 rule gather_annotated_calls:
     input:
-        calls=gather.calling("results/calls/{{group}}.orthanq.{scatteritem}.bcf"),
-        idx=gather.calling("results/calls/{{group}}.orthanq.{scatteritem}.bcf.csi"),
+        calls=gather.calling("results/calls/{{group}}.{locus}.orthanq.{scatteritem}.bcf"),
+        idx=gather.calling("results/calls/{{group}}.{locus}.orthanq.{scatteritem}.bcf.csi"),
     output:
-        "results/calls/{group}.hla-variants.bcf",
+        "results/calls/{group}.{locus}.hla-variants.bcf",
     log:
-        "logs/gather-hla-variants/{group}.log",
+        "logs/gather-hla-variants/{group}.{locus}.log",
     params:
         extra="-a",
     group:
@@ -27,14 +63,24 @@ rule gather_annotated_calls:
 
 rule orthanq_call:
     input:
-        "results/calls/{group}.hla-variants.bcf",
-    output:
-        "results/hla-typing/{group}.{sample}.tsv",
+        haplotype_variants="results/candidate-calls/orthanq.{locus}.bcf",
+        haplotype_calls="results/calls/{group}.{locus).hla-variants.bcf",
+        xml="results/preparation/hla.xml",
+    output: #orthanq uses underscore for a separator of sample/group name and locus name.
+        table="results/hla-typing/{group}_{locus}/{group}_{locus}.csv",
+        three_field_solutions="results/hla-typing/{group}_{locus}/3_field_solutions.json",
+        two_field_solutions="results/hla-typing/{group}_{locus}/2_field_solutions.json",
+        final_solution="results/hla-typing/{group}_{locus}/final_solution.json",
+        lp_solution="results/hla-typing/{group}_{locus}/lp_solution.json",
+        two_field_table="results/hla-typing/{group}_{locus}/2-field.csv",
+        g_groups="results/hla-typing/{group}_{locus}/G_groups.csv",
     log:
-        "logs/orthanq/{group}.{sample}.log",
+        "logs/orthanq/{group}.{locus}.log",
+    conda:
+        "../envs/orthanq.yaml"
     shell:
-        "orthanq call {input} --sample {wildcards.sample} --out-table {output} 2> {log}"
-
+        "orthanq call hla --haplotype-variants {input.haplotype_variants} --xml {input.xml} "
+        " --haplotype-calls {input.haplotype_calls} --prior diploid --output {output.table} 2> {log}"
 
 # TODO add other outputs (plots), fill missing inputs and commands
 # TODO decide how to handle deactivation of biases in varlociraptor:

--- a/workflow/rules/hla_typing.smk
+++ b/workflow/rules/hla_typing.smk
@@ -34,3 +34,8 @@ rule orthanq_call:
         "logs/orthanq/{group}.{sample}.log",
     shell:
         "orthanq call {input} --sample {wildcards.sample} --out-table {output} 2> {log}"
+
+
+# TODO add other outputs (plots), fill missing inputs and commands
+# TODO decide how to handle deactivation of biases in varlociraptor:
+# my current favorite is a special INFO tag in the orthanq candidates.

--- a/workflow/rules/hla_typing.smk
+++ b/workflow/rules/hla_typing.smk
@@ -19,6 +19,8 @@ rule unzip_xml:
         xml="results/preparation/hla.xml",
     log:
         "logs/unzip_xml.log",
+    conda:
+        "../envs/unzip.yaml"
     params:
         path_to_unzip=lambda wc, output: os.path.dirname(output.xml),
     shell:
@@ -31,16 +33,20 @@ rule orthanq_candidate_variants:
         xml="results/preparation/hla.xml",
         alleles="results/preparation/hla_gen.fasta",
     output:
-        temp(directory("results/orthanq-candidate-calls-temp/"))
+        directory("results/orthanq-candidate-calls-temp")
     log:
         "logs/orthanq_candidates/candidates.log",
-    threads: 8
+    conda:
+        "../envs/orthanq-deps.yaml" #only required for testing purposes
+    threads: 64
     params:
         command="candidates",
         subcommand="hla",
         output_bcf=True 
-    wrapper:
-        "v7.7.0/bio/orthanq"
+    # wrapper: #commented out for testing purposes
+    #     "v7.7.0/bio/orthanq"
+    shell:
+        "../../orthanq/target/release/orthanq candidates hla --alleles {input.alleles} --genome {input.genome} --xml {input.xml} --threads {threads} --output-bcf --output {output} 2> {log}"
 
 
 rule rename_candidate_bcf:
@@ -92,17 +98,75 @@ rule orthanq_call_hla:
         haplotype_variants="results/orthanq-candidate-calls/{caller}.hla-variants.bcf",
         xml="results/preparation/hla.xml",
     output:
-        directory("results/hla-typing/{group}-{caller}/{alias}")
+        # output_dir=directory("results/hla-typing/{group}-{caller}/{alias}/{prior}"),
+        predictions="results/hla-typing/{group}-{caller}/{alias}/{prior}/predictions.csv",
+        G_groups="results/hla-typing/{group}-{caller}/{alias}/{prior}/G_groups.csv",
+        three_field="results/hla-typing/{group}-{caller}/{alias}/{prior}/3_field_solutions.json",
+        two_field="results/hla-typing/{group}-{caller}/{alias}/{prior}/2_field_solutions.json",
+        best_solution="results/hla-typing/{group}-{caller}/{alias}/{prior}/best_solution.json",
+        arrow_plot="results/hla-typing/{group}-{caller}/{alias}/{prior}/arrow_plot.json"
     log:
-        "logs/orthanq/{group}-{alias}-{caller}.log",
+        "logs/orthanq/{group}-{alias}-{caller}-{prior}.log",
+    # wildcard_constraints:
+    #     alias="[^/]+",
+    #     prior="[^/]+",
+    #     caller="[^/]+",
+    #     group="[^/]+"
     params:
         command="call",
         subcommand="hla",
-        prior="diploid",
-        extra=""
-    wrapper:
-        "v7.7.0/bio/orthanq"
-        
-# TODO add other outputs (plots), fill missing inputs and commands
-# TODO decide how to handle deactivation of biases in varlociraptor:
-# my current favorite is a special INFO tag in the orthanq candidates.
+        # prior=lambda wc: lambda wc: "diploid" if wc.alias == "normal" else "diploid-subclonal", # todo: activate when diploid-subclonal is available.
+        prior= "diploid",
+        extra="",
+        outdir=lambda wc, output: os.path.dirname(output.three_field),
+        events=lambda wc: get_events,
+        allele_freqs="resources/allele_frequencies.csv"
+    # wrapper:
+    #     "v7.7.0/bio/orthanq"
+    conda:
+        "../envs/vega.yaml"
+    shell:
+        """
+        ../../orthanq/target/release/orthanq call hla \
+         --haplotype-variants {input.haplotype_variants} \
+         --xml {input.xml} --haplotype-calls {input.haplotype_calls} \
+         --prior {params.prior} --output {params.outdir} \
+         --sample {wildcards.alias} \
+         --allele-freqs {params.allele_freqs} \
+         --fast \
+         --events {params.events}  2> {log}
+        """
+
+rule convert_orthanq_plots:
+    input:
+        three_field="results/hla-typing/{group}-{caller}/{alias}/{prior}/3_field_solutions.json",
+        two_field="results/hla-typing/{group}-{caller}/{alias}/{prior}/2_field_solutions.json",
+        best_solution="results/hla-typing/{group}-{caller}/{alias}/{prior}/best_solution.json",
+        arrow_plot="results/hla-typing/{group}-{caller}/{alias}/{prior}/arrow_plot.json"
+    output:
+        three_field_html="results/hla-typing/{group}-{caller}/{alias}/{prior}/3_field_solutions.html",
+        three_field_svg="results/hla-typing/{group}-{caller}/{alias}/{prior}/3_field_solutions.svg",
+        two_field_html="results/hla-typing/{group}-{caller}/{alias}/{prior}/2_field_solutions.html",
+        two_field_svg="results/hla-typing/{group}-{caller}/{alias}/{prior}/2_field_solutions.svg",
+        arrow_plot_html="results/hla-typing/{group}-{caller}/{alias}/{prior}/arrow_plot.html",
+        arrow_plot_svg="results/hla-typing/{group}-{caller}/{alias}/{prior}/arrow_plot.svg",
+        best_solution_html="results/hla-typing/{group}-{caller}/{alias}/{prior}/best_solution.html",
+        best_solution_svg="results/hla-typing/{group}-{caller}/{alias}/{prior}/best_solution.svg",
+    log:
+        "logs/convert_orthanq_plots/{group}-{alias}-{caller}-{prior}.log",
+    conda:
+        "../envs/vega.yaml"
+    shell:
+        "vl-convert vl2html --input {input.three_field} --output {output.three_field_html} 2> {log} && "
+        "vl2svg {input.three_field} {output.three_field_svg} 2> {log} && "
+        "vl-convert vl2html --input {input.two_field} --output {output.two_field_html} 2> {log} && "
+        "vl2svg {input.two_field} {output.two_field_svg} 2> {log} && "
+        "vl-convert vl2html --input {input.best_solution} --output {output.best_solution_html} 2> {log} && "
+        "vl2svg {input.best_solution} {output.best_solution_svg} 2> {log} && "
+        "vl-convert vl2html --input {input.arrow_plot} --output {output.arrow_plot_html} 2> {log} && "
+        "vl2svg {input.arrow_plot} {output.arrow_plot_svg} 2> {log}"
+
+
+# TODO: decide how to handle deactivation of biases in varlociraptor, decide if --omit-mapq-adjustment is required.
+# TODO: use wrappers (needs to be configured to be compliant with the latest orthanq outputs) for orthanq, make fast mode optional (remove orthanq-deps.yaml)
+# TODO: enable subclonal typing with Orthanq using diploid-subclonal prior. 

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -5,7 +5,7 @@ rule get_sra:
     log:
         "logs/get-sra/{accession}.log",
     wrapper:
-        "v5.0.2/bio/sra-tools/fasterq-dump"
+        "v7.7.0/bio/sra-tools/fasterq-dump"
 
 
 rule fastp_pipe:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - HLA typing pipeline added and enabled by default; configurable loci: A, B, C, DQB1.

- **Changes**
  - Reporting toggled off by default.
  - Reference release set to 108.
  - Several analysis selections narrowed to somatic_tumor (including mutational burden/signatures and population DB); FDR-control events updated to include somatic_tumor and somatic_normal.
  - varlociraptor dependency updated.

- **Chores**
  - New conda environments for HLA tooling and helpers; orthanq pinned to 1.15.0.
  - Updated SRA wrapper version and CI cleanup flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->