### PR TITLE
fix: fix vembrane table output

### DIFF
--- a/workflow/rules/table.smk
+++ b/workflow/rules/table.smk
@@ -11,7 +11,7 @@ rule vembrane_table:
     log:
         "logs/vembrane-table/{group}.{event}.{calling_type}.log",
     shell:
-        'vembrane table --header "{params.config[header]}" "{params.config[expr]}" '
+        'vembrane table --wide --header "{params.config[header]}" "{params.config[expr]}" '
         "{input.bcf} > {output.bcf} 2> {log}"
 
 


### PR DESCRIPTION
`vambrane table` had a breaking change creating an additional `SAMPLE` column resulting in duplicated entries in the datavzrd report. This can be fixed by adding the `--wide`parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tables now support wider output formatting to better display content and improve readability of generated table results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->