### PR TITLE
fix: Add optional field to variant calls template

### DIFF
--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -290,6 +290,7 @@ views:
           feature:
             display-mode: hidden
           binned max vaf:
+            optional: true
             display-mode: hidden
           swissprot:
             optional: true
@@ -479,6 +480,7 @@ views:
           feature:
             display-mode: hidden
           binned max vaf:
+            optional: true
             display-mode: hidden
           hgvsg:
             optional: true


### PR DESCRIPTION
Makes `binned max vaf` column optional. Might make sense to add `include_lowest=True` to https://github.com/snakemake-workflows/dna-seq-varlociraptor/blob/85ca86e64d0e1451542b43abae13ba64ad55ba1e/workflow/scripts/split-call-tables.py#L152. 

CC @FelixMoelder 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made the "binned max vaf" column optional in variant call rendering for both coding and noncoding variant displays, providing greater flexibility in data visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->