### PR TITLE
perf: mark more non-permanent intermediate results as temp/pipe

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1615,7 +1615,7 @@ def get_multiqc_input(wildcards):
 
     # fastp
     if sample_units["adapters"].notna().all():
-        pattern = "results/trimmed/{unit.sample_name}/{unit.unit_name}.{mode}.qc.json"
+        pattern = "results/trimmed/{unit.sample_name}/{unit.unit_name}.{mode}.json"
         yield from expand(
             pattern, unit=sample_units[paired_end_units].itertuples(), mode="paired"
         )

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -134,7 +134,7 @@ rule bedtools_merge:
         left="results/regions/{group}/{sample}.regions.bed.gz",
         right="results/regions/{group}.covered_regions.bed",
     output:
-        "results/coverage/{group}/{sample}.regions.filtered.bed",
+        temp("results/coverage/{group}/{sample}.regions.filtered.bed"),
     log:
         "logs/bedtools/{group}/{sample}.log",
     params:

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -17,7 +17,7 @@ rule count_sample_kmers:
     input:
         reads=get_map_reads_input,
     output:
-        "results/kmers/{sample}.kff",
+        temp("results/kmers/{sample}.kff"),
     params:
         out_file=lambda wc, output: os.path.splitext(output[0])[0],
         mem=lambda wc, resources: resources.mem[:-2],
@@ -38,7 +38,7 @@ rule count_sample_kmers:
 
 rule create_reference_paths:
     output:
-        "resources/reference_paths.txt",
+        temp("resources/reference_paths.txt"),
     params:
         build=config["ref"]["build"],
     log:
@@ -254,7 +254,7 @@ rule splitncigarreads:
         ),
         ref=genome,
     output:
-        "results/split/{sample}.bam",
+        temp("results/split/{sample}.bam"),
     log:
         "logs/gatk/splitNCIGARreads/{sample}.log",
     params:

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -65,10 +65,11 @@ rule merge_trimmed_fastqs:
     input:
         get_trimmed_fastqs,
     output:
-        "results/merged/{sample}_{read}.fastq.gz",
+        pipe("results/merged/{sample}_{read}.fastq.gz"),
     log:
         "logs/merge-fastqs/trimmed/{sample}_{read}.log",
     wildcard_constraints:
         read="single|R1|R2",
+    threads: 0  # this does not need CPU
     shell:
         "cat {input} > {output} 2> {log}"

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -26,7 +26,7 @@ rule bam_index:
     input:
         "{prefix}.bam",
     output:
-        "{prefix}.bai",
+        temp("{prefix}.bai"),
     log:
         "logs/bam-index/{prefix}.log",
     wrapper:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized intermediate file cleanup by marking several generated files as temporary, reducing disk usage during runs.
  * Adjusted how the merged FASTQ output is produced/handled, improving streaming behavior.
  * Marked the BAM index output as temporary to further limit retained artifacts after completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->