### PR TITLE
fix: Fix datavzrd config for non-coding variants view and hide short observations

### DIFF
--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -382,6 +382,9 @@ views:
               optional: true
               custom: ?make_inspect_link(alias)
               display-mode: normal
+            '?f"{alias}: short observations"':
+              optional: true
+              display-mode: hidden
           spliceai:
             optional: true
             plot:
@@ -478,6 +481,8 @@ views:
                   - "#ff7f0e"
                   - "#a8d2f0"
                   - "#1f77b4"
+          "regex('.+: allele frequency distribution')":
+            display-mode: hidden
           "regex('.+: read depth')":
             plot:
               ticks:
@@ -558,6 +563,9 @@ views:
               optional: true
               custom: ?make_inspect_link(alias)
               display-mode: normal
+            '?f"{alias}: short observations"':
+              optional: true
+              display-mode: hidden
           spliceai:
             optional: true
             plot:


### PR DESCRIPTION
This pull request introduces several updates to the `variant-calls-template.datavzrd.yaml` configuration by hiding the allele frequency distribution column for the non-coding variants view and the short observations from both. Pretty much a follow up with some fixes for #445.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended template configuration to support per-sample short observations columns (optional, hidden by default).
  * Updated noncoding view to hide allele frequency distribution columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->