### PR TITLE
fix: calculate group specific pangenomes (improving consistency of read alignments; auto-optimizing for diploid and non-diploid calling scenarios)

### DIFF
--- a/workflow/envs/vg.yaml
+++ b/workflow/envs/vg.yaml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - nodefaults
+dependencies:
+  - vg =1.73.0

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -426,7 +426,11 @@ def get_map_reads_input(wildcards):
 
 def get_sample_pangenome_prefix(wildcards):
     group = samples.loc[wildcards.sample, "group"]
-    return f"results/pangenomes/by_group/{group}"
+    if len(samples.loc[samples["group"] == group]) > 1:
+        return f"results/pangenomes/by_group/{group}"
+    else:
+        # No need to create group pangenome
+        return f"results/pangenomes/by_sample/{wildcards.sample}"
 
 
 def get_sample_scenario(wildcards):
@@ -1716,7 +1720,7 @@ def get_alignment_props(wildcards):
     return f"results/alignment-properties/{wildcards.group}/{wildcards.sample}.json"
 
 
-def get_pangenome_url(datatype):
+def get_pangenome_url():
     build = config["ref"]["build"].lower()
     source = config["ref"]["pangenome"]["source"]
     version = config["ref"]["pangenome"]["version"]
@@ -1731,5 +1735,5 @@ def get_pangenome_url(datatype):
     return (
         "https://s3-us-west-2.amazonaws.com/human-pangenomics/pangenomes/freeze/"
         "freeze1/minigraph-cactus/"
-        f"hprc-{version}-mc-{build}/hprc-{version}-mc-{build}.{datatype}"
+        f"hprc-{version}-mc-{build}/hprc-{version}-mc-{build}.gbz"
     )

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -425,8 +425,13 @@ def get_map_reads_input(wildcards):
 
 
 def get_sample_pangenome_prefix(wildcards):
-    group = lookup(query="sample_name == '{sample}'", within=samples, cols="group")
-    return f"results/pangenomes/{group}"
+    group = samples.loc[wildcards.sample, "group"]
+    return f"results/pangenomes/by_group/{group}"
+
+
+def get_sample_scenario(wildcards):
+    group = samples.loc[wildcards.sample, "group"]
+    return f"results/scenarios/{group}.yaml"
 
 
 def get_haplotype_args(wildcards, input):
@@ -1642,7 +1647,7 @@ def get_multiqc_input(wildcards):
 
     # fastp
     if sample_units["adapters"].notna().all():
-        pattern = "results/trimmed/{unit.sample_name}/{unit.unit_name}.{mode}.qc.json"
+        pattern = "results/trimmed/{unit.sample_name}/{unit.unit_name}.{mode}.json"
         yield from expand(
             pattern, unit=sample_units[paired_end_units].itertuples(), mode="paired"
         )

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -424,6 +424,33 @@ def get_map_reads_input(wildcards):
     return "results/merged/{sample}_single.fastq.gz"
 
 
+def get_sample_pangenome_prefix(wildcards):
+    group = lookup(query="sample_name == '{sample}'", within=samples, cols="group")
+    return f"results/pangenomes/{group}"
+
+
+def get_haplotype_args(wildcards, input):
+    with open(input.scenario) as scenario:
+        scenario = yaml.safe_load(scenario)
+        alias = samples.loc[wildcards.sample, "alias"]
+
+        try:
+            settings = scenario["samples"][alias]
+        except KeyError:
+            raise ValueError(
+                f"Sample alias {sample.alias} does not occur in scenario of group {wildcards.group}"
+            )
+
+        is_diploid = (
+            "[" not in settings.get("universe", "")
+            and "somatic-effective-mutation-rate" not in settings
+        )
+        if is_diploid:
+            return "--diploid-sampling"
+        else:
+            return "--num-haplotypes 32"
+
+
 def get_star_reads_input(wildcards, r2=False):
     match (bool(is_paired_end(wildcards.sample)), r2):
         case (True, False):

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -36,6 +36,50 @@ rule count_sample_kmers:
         "rm -r $tmpdir || (rm -r $tmpdir && exit 1)"
 
 
+rule obtain_sample_pangenome:
+    input:
+        kmers=access.sequential("results/kmers/{sample}.kff"),
+        graph=access.random(f"{pangenome_prefix}.gbz"),
+        hapl=access.random(f"{pangenome_prefix}.hapl"),
+        scenario=lookup(query="sample_name == '{sample}'", cols="group", within=samples),
+    output:
+        temp("results/pangenomes/by_sample/{sample}.gbz"),
+    log:
+        "logs/vg_haplotypes/{sample}.log",
+    threads: 64
+    params:
+        haplotype_args=get_haplotype_args,
+    shell:
+        "vg haplotypes --threads {threads} -k {input.kmers} -i {input.hapl} "
+        "{params.haplotype_args} --include-reference -g {output} 2> {log}"
+
+
+rule merge_sample_pangenomes:
+    input:
+        per_sample=access.random(
+            collect(
+                "results/pangenomes/by_sample/{sample}.gbz",
+                sample=lookup(
+                    query="group == '{group}'", cols="sample_name", within=samples
+                ),
+            )
+        ),
+        full=access.random(f"{pangenome_prefix}.gbz"),
+    output:
+        gbz=temp("results/pangenomes/by_group/{group}.gbz"),
+        dist=temp("results/pangenomes/by_group/{group}.dist"),
+        min=temp("results/pangenomes/by_group/{group}.min"),
+    log:
+        "logs/vg_gbwt/{group}.log",
+    threads: 64
+    shell:
+        "(vg gbwt --gbz-input --num-jobs 1 --num-threads {threads} -x {input.full} "
+        " -g {output.gbz} -m {input.per_sample};  "
+        " vg index --threads {threads} -j {output.dist} {output.gbz}; "
+        " vg minimizer -p --threads {threads} -o {output.min} "
+        " -d {output.dist} {output.gbz}) 2> {log}"
+
+
 rule create_reference_paths:
     output:
         "resources/reference_paths.txt",
@@ -50,21 +94,13 @@ rule create_reference_paths:
 rule map_reads_vg:
     input:
         reads=get_map_reads_input,
-        graph=access.random(f"{pangenome_prefix}.gbz"),
-        kmers=access.random("results/kmers/{sample}.kff"),
+        graph=access.random(subpath(get_sample_pangenome_prefix, with_suffix=".gbz")),
+        dist=access.random(subpath(get_sample_pangenome_prefix, with_suffix=".dist")),
+        min=access.random(subpath(get_sample_pangenome_prefix, with_suffix=".min")),
         hapl=access.random(f"{pangenome_prefix}.hapl"),
         paths=access.random("resources/reference_paths.txt"),
     output:
         bam=temp("results/mapped/vg/{sample}.raw.bam"),
-        indexes=temp(
-            multiext(
-                f"{pangenome_prefix}.{{sample}}",
-                ".gbz",
-                ".dist",
-                ".shortread.withzip.min",
-                ".shortread.zipcodes",
-            )
-        ),
     log:
         "logs/mapped/vg/{sample}.log",
     benchmark:

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -86,21 +86,36 @@ rule merge_sample_pangenomes:
         " -d {output.dist} {output.gbz}) 2> {log}"
 
 
-rule index_pangenome:
+rule pangenome_index:
     input:
         "results/pangenomes/{infix}.gbz",
     output:
         dist="results/pangenomes/{infix}.dist",
-        min="results/pangenomes/{infix}.min",
     log:
-        "logs/vg_index_minimizer/{infix}.log"
+        "logs/vg_index/{infix}.log"
     threads: 64
     conda:
         "../envs/vg.yaml"
     shell:
-        "(vg index --threads {threads} -j {output.dist} {input}; "
-        " vg minimizer -k 29 -w 11 -p --threads {threads} -o {output.min} "
-        " -d {output.dist} {input}) 2> {log}"
+        "vg index --threads {threads} -j {output.dist} {input} 2> {log}"
+
+
+rule pangenome_minimizers:
+    input:
+        gbz="results/pangenomes/{infix}.gbz",
+        dist="results/pangenomes/{infix}.dist",
+    output:
+        min="results/pangenomes/{infix}.min",
+        zipcodes="results/pangenomes/{infix}.zipcodes",
+    log:
+        "logs/vg_minimizer/{infix}.log"
+    threads: 64
+    conda:
+        "../envs/vg.yaml"
+    shell:
+        # TODO, for long reads, we need different k and w params!
+        "vg minimizer -k 29 -w 11 -p --threads {threads} -o {output.min} "
+        "-z {output.zipcodes} -d {input.dist} {input.gbz} 2> {log}"
 
 
 rule create_reference_paths:
@@ -120,6 +135,7 @@ rule map_reads_vg:
         graph=access.random(subpath(get_sample_pangenome_prefix, with_suffix=".gbz")),
         dist=access.random(subpath(get_sample_pangenome_prefix, with_suffix=".dist")),
         min=access.random(subpath(get_sample_pangenome_prefix, with_suffix=".min")),
+        zipcodes=access.random(subpath(get_sample_pangenome_prefix, with_suffix=".zipcodes")),
         hapl=access.random(f"{pangenome_prefix}.hapl"),
         paths=access.random("resources/reference_paths.txt"),
     output:
@@ -130,10 +146,10 @@ rule map_reads_vg:
         "benchmarks/vg_giraffe/{sample}.tsv"
     threads: 64
     params:
-        extra=lambda wc, input: f"--ref-paths {input.paths}",
+        extra=lambda w, input: f"--ref-paths {input.paths} --dist-name {input.dist} --zipcode-name {input.zipcodes} --minimizer-name {input.min}",
         sorting="none",
     wrapper:
-        "v6.1.0/bio/vg/giraffe"
+        "v9.9.0/bio/vg/giraffe"
 
 
 rule reheader_mapped_reads:

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -46,12 +46,14 @@ rule obtain_sample_pangenome:
         temp("results/pangenomes/by_sample/{sample}.gbz"),
     log:
         "logs/vg_haplotypes/{sample}.log",
-    threads: 64
+    threads: 16 # vg only allows up to 16 threads
+    conda:
+        "../envs/vg.yaml"
     params:
         haplotype_args=get_haplotype_args,
     shell:
         "vg haplotypes --threads {threads} -k {input.kmers} -i {input.hapl} "
-        "{params.haplotype_args} --include-reference -g {output} 2> {log}"
+        "{params.haplotype_args} --include-reference -g {output} {input.graph} 2> {log}"
 
 
 rule merge_sample_pangenomes:
@@ -72,12 +74,33 @@ rule merge_sample_pangenomes:
     log:
         "logs/vg_gbwt/{group}.log",
     threads: 64
+    conda:
+        "../envs/vg.yaml"
+    params:
+        to_merge=expand("<({sample_graph})", sample_graph=input.per_sample),
     shell:
-        "(vg gbwt --gbz-input --num-jobs 1 --num-threads {threads} -x {input.full} "
-        " -g {output.gbz} -m {input.per_sample};  "
+        "(vg gbwt --gbz-format --num-jobs 1 --num-threads {threads} -x {input.full} "
+        " -g {output.gbz} -m {params.to_merge}; "
         " vg index --threads {threads} -j {output.dist} {output.gbz}; "
         " vg minimizer -p --threads {threads} -o {output.min} "
         " -d {output.dist} {output.gbz}) 2> {log}"
+
+
+rule index_pangenome:
+    input:
+        "results/pangenomes/{infix}.gbz",
+    output:
+        dist="results/pangenomes/{infix}.dist",
+        min="results/pangenomes/{infix}.min",
+    log:
+        "logs/vg_index_minimizer/{infix}.log"
+    threads: 64
+    conda:
+        "../envs/vg.yaml"
+    shell:
+        "(vg index --threads {threads} -j {output.dist} {input}; "
+        " vg minimizer -k 29 -w 11 -p --threads {threads} -o {output.min} "
+        " -d {output.dist} {input}) 2> {log}"
 
 
 rule create_reference_paths:

--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -41,7 +41,7 @@ rule obtain_sample_pangenome:
         kmers=access.sequential("results/kmers/{sample}.kff"),
         graph=access.random(f"{pangenome_prefix}.gbz"),
         hapl=access.random(f"{pangenome_prefix}.hapl"),
-        scenario=lookup(query="sample_name == '{sample}'", cols="group", within=samples),
+        scenario=get_sample_scenario,
     output:
         temp("results/pangenomes/by_sample/{sample}.gbz"),
     log:

--- a/workflow/rules/ref.smk
+++ b/workflow/rules/ref.smk
@@ -151,13 +151,55 @@ rule get_vep_plugins:
 
 rule get_pangenome:
     output:
-        f"{pangenome_prefix}.{{ext}}",
+        f"{pangenome_prefix}.gbz",
     log:
-        "logs/pangenome/{ext}.log",
-    wildcard_constraints:
-        ext="hapl|gbz",
+        "logs/get_pangenome.log",
     cache: "omit-software"
     params:
-        url=lambda wc: get_pangenome_url(wc.ext),
+        url=get_pangenome_url(),
     shell:
         "curl -o {output} {params.url} 2> {log}"
+
+
+rule pangenome_dist_index:
+    input:
+        f"{pangenome_prefix}.gbz",
+    output:
+        f"{pangenome_prefix}.dist"
+    log:
+        "logs/pangenome_dist_index.log"
+    conda:
+        "../envs/vg.yaml"
+    threads: 16
+    shell:
+        "vg index --threads {threads} -j {output} --no-nested-distance {input} 2> {log}"
+
+
+rule pangenome_r_index:
+    input:
+        f"{pangenome_prefix}.gbz",
+    output:
+        f"{pangenome_prefix}.ri"
+    log:
+        "logs/pangenome_r_index.log"
+    conda:
+        "../envs/vg.yaml"
+    threads: 16
+    shell:
+        "vg gbwt --num-threads {threads} -r {output} -Z {input} 2> {log}"
+
+
+rule pangenome_hapl_index:
+    input:
+        gbz=f"{pangenome_prefix}.gbz",
+        ri=f"{pangenome_prefix}.ri",
+        dist=f"{pangenome_prefix}.dist",
+    output:
+        f"{pangenome_prefix}.hapl"
+    log:
+        "logs/pangenome_hapl_index.log"
+    conda:
+        "../envs/vg.yaml"
+    threads: 16
+    shell:
+        "vg haplotypes --threads {threads} -H {output} {input.gbz} 2> {log}"

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -65,7 +65,7 @@ rule merge_trimmed_fastqs:
     input:
         get_trimmed_fastqs,
     output:
-        "results/merged/{sample}_{read}.fastq.gz",
+        temp("results/merged/{sample}_{read}.fastq.gz"),
     log:
         "logs/merge-fastqs/trimmed/{sample}_{read}.log",
     wildcard_constraints:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helper logic to derive per-sample scenario/pangenome paths and haplotype CLI arguments.
  * Introduced per-sample pangenome graph construction and group-level pangenome merging for mapping.
  * Added dedicated indexing steps for pangenome-derived downstream artifacts.
* **Bug Fixes**
  * Improved scenario handling by validating sample aliases and selecting haplotype settings from scenario configuration.
  * Updated MultiQC to match trimmed FASTQ JSON artifact naming.
* **Refactor**
  * Rewired mapping to use newly generated sample-specific pangenome artifacts.
  * Marked merged trimmed FASTQ outputs as temporary to streamline intermediates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->