### PR TITLE
perf: update datavzrd wrapper to 9.17.1

### DIFF
--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -96,7 +96,7 @@ rule datavzrd_variants_calls:
             dpath="calling/fdr-control/events/{event}/desc", within=config
         ),
     wrapper:
-        "v9.17.0/utils/datavzrd"
+        "v9.17.1/utils/datavzrd"
 
 
 rule datavzrd_fusion_calls:
@@ -123,7 +123,7 @@ rule datavzrd_fusion_calls:
         species=lookup(within=config, dpath="ref/species"),
         samples=samples,
     wrapper:
-        "v9.17.0/utils/datavzrd"
+        "v9.17.1/utils/datavzrd"
 
 
 rule bedtools_merge:
@@ -177,4 +177,4 @@ rule datavzrd_coverage:
     params:
         samples=lambda wc: get_group_samples(wc.group),
     wrapper:
-        "v9.17.0/utils/datavzrd"
+        "v9.17.1/utils/datavzrd"

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -96,7 +96,7 @@ rule datavzrd_variants_calls:
             dpath="calling/fdr-control/events/{event}/desc", within=config
         ),
     wrapper:
-        "v9.14.0/utils/datavzrd"
+        "v9.17.0/utils/datavzrd"
 
 
 rule datavzrd_fusion_calls:
@@ -123,7 +123,7 @@ rule datavzrd_fusion_calls:
         species=lookup(within=config, dpath="ref/species"),
         samples=samples,
     wrapper:
-        "v9.14.0/utils/datavzrd"
+        "v9.17.0/utils/datavzrd"
 
 
 rule bedtools_merge:
@@ -177,4 +177,4 @@ rule datavzrd_coverage:
     params:
         samples=lambda wc: get_group_samples(wc.group),
     wrapper:
-        "v9.14.0/utils/datavzrd"
+        "v9.17.0/utils/datavzrd"


### PR DESCRIPTION
This uses datavzrd 2.72.2, which has several improvements to reduce runtime and memory usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Datavzrd integration to version 9.17.1 for variant calls, fusion calls, and coverage workflows.
  * Existing inputs, outputs, parameters, and workflow behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->