### PR TITLE
perf: share oncoprint heatmap color domains

### DIFF
--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -8,6 +8,7 @@ max-in-memory-rows: 1500
 __definitions__:
   - import os
   - import pandas as pd
+  - import json
   - |
     def read_file(path):
         return open(path, 'r').read()

--- a/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
+++ b/workflow/resources/datavzrd/variant-calls-template.datavzrd.yaml
@@ -205,7 +205,7 @@ views:
                   heatmap:
                     scale: ordinal
                     color-scheme: paired
-                    aux-domain-columns: ?list(params.groups)
+                    domain: ?json.load(open(input.color_domains))["gene"]
                     legend:
                       title: variant
                 ellipsis: 0
@@ -258,7 +258,7 @@ views:
                   heatmap:
                     scale: ordinal
                     color-scheme: paired
-                    aux-domain-columns: ?list(params.groups)
+                    domain: ?json.load(open(input.color_domains))["variant"]
                 ellipsis: 0
             hgvsg:
               display-mode: hidden

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1720,6 +1720,8 @@ def get_oncoprint(oncoprint_type):
                 return f"{oncoprint_path}/gene-oncoprint.tsv"
             elif oncoprint_type == "variant":
                 return f"{oncoprint_path}/variant-oncoprints"
+            elif oncoprint_type == "color_domains":
+                return f"{oncoprint_path}/color-domains.json"
             else:
                 raise ValueError(f"bug: unsupported oncoprint type {oncoprint_type}")
         else:

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -50,6 +50,7 @@ rule prepare_oncoprint:
         variant_oncoprints=directory(
             "results/tables/oncoprints/{batch}.{event}/variant-oncoprints"
         ),
+        color_domains="results/tables/oncoprints/{batch}.{event}/color-domains.json",
     log:
         "logs/prepare_oncoprint/{batch}.{event}.log",
     conda:
@@ -71,6 +72,7 @@ rule datavzrd_variants_calls:
         gene_oncoprint=get_oncoprint("gene"),
         variant_oncoprints=get_oncoprint("variant"),
         oncoprint_sorted_datasets="results/tables/oncoprints/{batch}.{event}/label_sortings/",
+        color_domains="results/tables/oncoprints/{batch}.{event}/color-domains.json",
     output:
         report(
             directory(

--- a/workflow/rules/datavzrd.smk
+++ b/workflow/rules/datavzrd.smk
@@ -72,7 +72,7 @@ rule datavzrd_variants_calls:
         gene_oncoprint=get_oncoprint("gene"),
         variant_oncoprints=get_oncoprint("variant"),
         oncoprint_sorted_datasets="results/tables/oncoprints/{batch}.{event}/label_sortings/",
-        color_domains="results/tables/oncoprints/{batch}.{event}/color-domains.json",
+        color_domains=get_oncoprint("color_domains"),
     output:
         report(
             directory(

--- a/workflow/scripts/oncoprint.py
+++ b/workflow/scripts/oncoprint.py
@@ -119,7 +119,7 @@ def gene_oncoprint(calls):
         )
 
 
-def variant_oncoprint(gene_calls, group_annotation):
+def variant_oncoprint(gene_calls):
     gene_calls = gene_calls[["group", "hgvsp", "hgvsc", "hgvsg", "consequence"]]
     gene_calls.loc[:, "exists"] = "+"
 
@@ -145,8 +145,6 @@ def variant_oncoprint(gene_calls, group_annotation):
     if len(matrix.columns) > 1:
         # sort by recurrence
         matrix = sort_by_recurrence(matrix, lambda matrix: matrix.isna())
-
-    matrix = attach_group_annotation(matrix, group_annotation)
 
     return matrix
 
@@ -253,13 +251,13 @@ sort_oncoprint_labels(gene_oncoprint)
 os.makedirs(snakemake.output.variant_oncoprints)
 variant_values = set()
 for gene, gene_calls in calls.groupby("symbol", observed=False):
-    matrix = variant_oncoprint(gene_calls, group_annotation)
-    matrix.to_csv(
-        Path(snakemake.output.variant_oncoprints) / f"{gene}.tsv", sep="\t", index=False
-    )
+    matrix = variant_oncoprint(gene_calls)
     for group in snakemake.params.groups:
         if group in matrix.columns:
             variant_values.update(matrix[group].dropna().unique())
+    attach_group_annotation(matrix, group_annotation).to_csv(
+        Path(snakemake.output.variant_oncoprints) / f"{gene}.tsv", sep="\t", index=False
+    )
 
 color_domains = {
     "gene": sorted(

--- a/workflow/scripts/oncoprint.py
+++ b/workflow/scripts/oncoprint.py
@@ -2,6 +2,7 @@ import sys
 
 sys.stderr = open(snakemake.log[0], "w")
 
+import json
 import os
 from pathlib import Path
 
@@ -250,7 +251,25 @@ sort_oncoprint_labels(gene_oncoprint)
 
 
 os.makedirs(snakemake.output.variant_oncoprints)
+variant_values = set()
 for gene, gene_calls in calls.groupby("symbol", observed=False):
-    variant_oncoprint(gene_calls, group_annotation).to_csv(
+    matrix = variant_oncoprint(gene_calls, group_annotation)
+    matrix.to_csv(
         Path(snakemake.output.variant_oncoprints) / f"{gene}.tsv", sep="\t", index=False
     )
+    for group in snakemake.params.groups:
+        if group in matrix.columns:
+            variant_values.update(matrix[group].dropna().unique())
+
+color_domains = {
+    "gene": sorted(
+        {
+            value
+            for group in snakemake.params.groups
+            for value in gene_oncoprint[group].dropna().unique()
+        }
+    ),
+    "variant": sorted(variant_values),
+}
+with open(snakemake.output.color_domains, "w") as handle:
+    json.dump(color_domains, handle)

--- a/workflow/scripts/oncoprint.py
+++ b/workflow/scripts/oncoprint.py
@@ -264,6 +264,7 @@ color_domains = {
         {
             value
             for group in snakemake.params.groups
+            if group in gene_oncoprint.columns
             for value in gene_oncoprint[group].dropna().unique()
         }
     ),


### PR DESCRIPTION
Sample-column heatmaps in the variant oncoprint currently set `aux-domain-columns` to the full list of groups on every column, so the rendered datavzrd config contains the group list once per column per gene view — quadratic in the number of samples and multiplied by the number of genes. For a report with ~1140 samples and ~1850 genes this is tens of gigabytes of config, and parsing it needs hundreds of gigabytes of memory.

This PR fixes this by pre-calculating the domains so they do not bloat the config file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Oncoprint overview heatmaps now use explicitly defined color domains for genes and variants.
  - Color scales are based on the complete set of available values, including values represented in the generated oncoprint data.
  - Gene and variant views now provide more consistent and predictable heatmap coloring.
  - Color-domain data is generated and applied automatically during oncoprint processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->